### PR TITLE
Fix misspelled/wrong word

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ receive DCR.
 
 ## Features
 
-1. Pure-Python secp256k1 elliptical curve.
+1. Pure-Python secp256k1 elliptic curve.
 
 1. Serializable and de-serializable python versions of important types
 from the dcrd/wire package: `MsgTx`, `BlockHeader`, `OutPoint`, etc. 


### PR DESCRIPTION
Secp256k1 is an elliptic curve, not an exercise machine.