### PR TITLE
Add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ directory.
 All dependencies are available through PyPi.
 
 ```
-pip install PyQt5==5.9.2 websocket_client blake256 base58 pynacl appdirs
+pip3 install -r requirements.txt
 ```
 
-though depending on your setup, you may need `sudo`, and `pip` might be `pip3`.
+though depending on your setup, you may need `sudo`, and `pip3` might be `pip`.
 
 You're probably okay to use newer versions of PyQt5, but `5.9.2` has been 
 remarkably stable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+PyQt5==5.9.2
+websocket_client
+blake256
+base58
+pynacl
+appdirs


### PR DESCRIPTION
Moved dependencies to requirements.txt file and updated readme. 

In systems with python3 as default pip is an alias of pip3. 
In systems with both py2 and py3, pip3 should be specified. 
So it makes sense to give the install instruction as `pip3` the user can error to `pip` if needed. 