### PR TITLE
Fix some examples in PyDecred's README

### DIFF
--- a/pydecred/README.md
+++ b/pydecred/README.md
@@ -81,72 +81,84 @@ input("press return to close")
 
 ### Example endpoint guide
 ```
-address.amountflow.get(address, chartgrouping)  ->  /address/{address}/amountflow/{chartgrouping}
-address.count.get(address, N)                   ->  /address/{address}/count/{N}
-address.count.raw.get(address, N)               ->  /address/{address}/count/{N}/raw
-address.count.skip.get(address, N, M)           ->  /address/{address}/count/{N}/skip/{M}
-address.count.skip.raw.get(address, N, M)       ->  /address/{address}/count/{N}/skip/{M}/raw
-address.raw.get(address)                        ->  /address/{address}/raw
-address.totals.get(address)                     ->  /address/{address}/totals
-address.types.get(address, chartgrouping)       ->  /address/{address}/types/{chartgrouping}
-address.unspent.get(address, chartgrouping)     ->  /address/{address}/unspent/{chartgrouping}
-block.best.get()                                ->  /block/best
-block.best.hash.get()                           ->  /block/best/hash
-block.best.header.get()                         ->  /block/best/header
-block.best.height.get()                         ->  /block/best/height
-block.best.pos.get()                            ->  /block/best/pos
-block.best.size.get()                           ->  /block/best/size
-block.best.subsidy.get()                        ->  /block/best/subsidy
-block.best.tx.get()                             ->  /block/best/tx
-block.best.tx.count.get()                       ->  /block/best/tx/count
-block.best.verbose.get()                        ->  /block/best/verbose
-block.hash.get(blockhash)                       ->  /block/hash/{blockhash}
-block.hash.header.get(blockhash)                ->  /block/hash/{blockhash}/header
-block.hash.height.get(blockhash)                ->  /block/hash/{blockhash}/height
-block.hash.pos.get(blockhash)                   ->  /block/hash/{blockhash}/pos
-block.hash.size.get(blockhash)                  ->  /block/hash/{blockhash}/size
-block.hash.subsidy.get(blockhash)               ->  /block/hash/{blockhash}/subsidy
-block.hash.tx.get(blockhash)                    ->  /block/hash/{blockhash}/tx
-block.hash.tx.count.get(blockhash)              ->  /block/hash/{blockhash}/tx/count
-block.hash.verbose.get(blockhash)               ->  /block/hash/{blockhash}/verbose
-block.range.get(idx0, idx)                      ->  /block/range/{idx0}/{idx}
-block.range.size.get(idx0, idx)                 ->  /block/range/{idx0}/{idx}/size
-block.range.get(idx0, idx, step)                ->  /block/range/{idx0}/{idx}/{step}
-block.range.size.get(idx0, idx, step)           ->  /block/range/{idx0}/{idx}/{step}/size
-block.hash.get(idx)                             ->  /block/{idx}/hash
-block.header.get(idx)                           ->  /block/{idx}/header
-block.pos.get(idx)                              ->  /block/{idx}/pos
-block.size.get(idx)                             ->  /block/{idx}/size
-block.subsidy.get(idx)                          ->  /block/{idx}/subsidy
-block.tx.get(idx)                               ->  /block/{idx}/tx
-block.tx.count.get(idx)                         ->  /block/{idx}/tx/count
-block.verbose.get(idx)                          ->  /block/{idx}/verbose
-mempool.sstx.get()                              ->  /mempool/sstx
-mempool.sstx.details.get()                      ->  /mempool/sstx/details
-mempool.sstx.details.get(N)                     ->  /mempool/sstx/details/{N}
-mempool.sstx.fees.get()                         ->  /mempool/sstx/fees
-mempool.sstx.fees.get(N)                        ->  /mempool/sstx/fees/{N}
-stake.diff.get()                                ->  /stake/diff
-stake.diff.b.get(idx)                           ->  /stake/diff/b/{idx}
-stake.diff.current.get()                        ->  /stake/diff/current
-stake.diff.estimates.get()                      ->  /stake/diff/estimates
-stake.diff.r.get(idx0, idx)                     ->  /stake/diff/r/{idx0}/{idx}
-stake.pool.get()                                ->  /stake/pool
-stake.pool.b.get(idx)                           ->  /stake/pool/b/{idx}
-stake.pool.b.full.get(idxorhash)                ->  /stake/pool/b/{idxorhash}/full
-stake.pool.full.get()                           ->  /stake/pool/full
-stake.pool.r.get(idx0, idx)                     ->  /stake/pool/r/{idx0}/{idx}
-stake.vote.get()                                ->  /stake/vote
-stake.vote.info.get()                           ->  /stake/vote/info
-ticketpool.bydate.get(tp)                       ->  /ticketpool/bydate/{tp}
-ticketpool.charts.get()                         ->  /ticketpool/charts
-tx.decoded.get(txid)                            ->  /tx/decoded/{txid}
-tx.hex.get(txid)                                ->  /tx/hex/{txid}
-tx.in.get(txid)                                 ->  /tx/{txid}/in
-tx.in.get(txid, txinoutindex)                   ->  /tx/{txid}/in/{txinoutindex}
-tx.out.get(txid)                                ->  /tx/{txid}/out
-tx.out.get(txid, txinoutindex)                  ->  /tx/{txid}/out/{txinoutindex}
-tx.trimmed.get(txid)                            ->  /tx/{txid}/trimmed
-tx.vinfo.get(txid)                              ->  /tx/{txid}/vinfo
-txs.trimmed.get()                               ->  /txs/trimmed
+address.amountflow(address, chartgrouping)      ->  /address/{address}/amountflow/{chartgrouping}
+address.count(address, N)                       ->  /address/{address}/count/{N}
+address.count.raw(address, N)                   ->  /address/{address}/count/{N}/raw
+address.count.skip(address, N, M)               ->  /address/{address}/count/{N}/skip/{M}
+address.count.skip.raw(address, N, M)           ->  /address/{address}/count/{N}/skip/{M}/raw
+address.raw(address)                            ->  /address/{address}/raw
+address.totals(address)                         ->  /address/{address}/totals
+address.types(address, chartgrouping)           ->  /address/{address}/types/{chartgrouping}
+block.best()                                    ->  /block/best
+block.best.hash()                               ->  /block/best/hash
+block.best.header()                             ->  /block/best/header
+block.best.header.raw()                         ->  /block/best/header/raw
+block.best.height()                             ->  /block/best/height
+block.best.pos()                                ->  /block/best/pos
+block.best.raw()                                ->  /block/best/raw
+block.best.size()                               ->  /block/best/size
+block.best.subsidy()                            ->  /block/best/subsidy
+block.best.tx()                                 ->  /block/best/tx
+block.best.tx.count()                           ->  /block/best/tx/count
+block.best.verbose()                            ->  /block/best/verbose
+block.hash(blockhash)                           ->  /block/hash/{blockhash}
+block.hash.header(blockhash)                    ->  /block/hash/{blockhash}/header
+block.hash.header.raw(blockhash                 ->  /block/hash/{blockhash}/header/raw
+block.hash.height(blockhash)                    ->  /block/hash/{blockhash}/height
+block.hash.pos(blockhash)                       ->  /block/hash/{blockhash}/pos
+block.hash.raw(blockhash)                       ->  /block/hash/{blockhash}/raw
+block.hash.size(blockhash)                      ->  /block/hash/{blockhash}/size
+block.hash.subsidy(blockhash)                   ->  /block/hash/{blockhash}/subsidy
+block.hash.tx(blockhash)                        ->  /block/hash/{blockhash}/tx
+block.hash.tx.count(blockhash)                  ->  /block/hash/{blockhash}/tx/count
+block.hash.verbose(blockhash)                   ->  /block/hash/{blockhash}/verbose
+block.range(idx0, idx)                          ->  /block/range/{idx0}/{idx}
+block.range.size(idx0, idx)                     ->  /block/range/{idx0}/{idx}/size
+block.range(idx0, idx, step)                    ->  /block/range/{idx0}/{idx}/{step}
+block.range.size(idx0, idx, step)               ->  /block/range/{idx0}/{idx}/{step}/size
+block.hash(idx)                                 ->  /block/{idx}/hash
+block.header(idx)                               ->  /block/{idx}/header
+block.header.raw(idx)                           ->  /block/{idx}/header/raw
+block.pos(idx)                                  ->  /block/{idx}/pos
+block.raw(idx)                                  ->  /block/{idx}/raw
+block.size(idx)                                 ->  /block/{idx}/size
+block.subsidy(idx)                              ->  /block/{idx}/subsidy
+block.tx(idx)                                   ->  /block/{idx}/tx
+block.tx.count(idx)                             ->  /block/{idx}/tx/count
+block.verbose(idx)                              ->  /block/{idx}/verbose
+chart.market(token)                             ->  /chart/market/{token}
+chart.market.candlestick(token, bin)            ->  /chart/market/{token}/candlestick/{bin}
+chart.market.depth(token)                       ->  /chart/market/{token}/depth
+exchanges.codes()                               ->  /exchanges/codes
+mempool.sstx()                                  ->  /mempool/sstx
+mempool.sstx.details()                          ->  /mempool/sstx/details
+mempool.sstx.details(N)                         ->  /mempool/sstx/details/{N}
+mempool.sstx.fees()                             ->  /mempool/sstx/fees
+mempool.sstx.fees(N)                            ->  /mempool/sstx/fees/{N}
+stake.diff()                                    ->  /stake/diff
+stake.diff.b(idx)                               ->  /stake/diff/b/{idx}
+stake.diff.current()                            ->  /stake/diff/current
+stake.diff.estimates()                          ->  /stake/diff/estimates
+stake.diff.r(idx0, idx)                         ->  /stake/diff/r/{idx0}/{idx}
+stake.pool()                                    ->  /stake/pool
+stake.pool.b(idx)                               ->  /stake/pool/b/{idx}
+stake.pool.b.full(idxorhash)                    ->  /stake/pool/b/{idxorhash}/full
+stake.pool.full()                               ->  /stake/pool/full
+stake.pool.r(idx0, idx)                         ->  /stake/pool/r/{idx0}/{idx}
+stake.powerless()                               ->  /stake/powerless
+stake.vote()                                    ->  /stake/vote
+stake.vote.info()                               ->  /stake/vote/info
+status.happy()                                  ->  /status/happy
+ticketpool.bydate(tp)                           ->  /ticketpool/bydate/{tp}
+ticketpool.charts()                             ->  /ticketpool/charts
+tx.decoded(txid)                                ->  /tx/decoded/{txid}
+tx.hex(txid)                                    ->  /tx/hex/{txid}
+tx.__getattr__("in")(txid)                      ->  /tx/{txid}/in
+tx.__getattr__("in")(txid, txinoutindex)        ->  /tx/{txid}/in/{txinoutindex}
+tx.out(txid)                                    ->  /tx/{txid}/out
+tx.out(txid, txinoutindex)                      ->  /tx/{txid}/out/{txinoutindex}
+tx.tinfo(txid)                                  ->  /tx/{txid}/tinfo
+tx.trimmed(txid)                                ->  /tx/{txid}/trimmed
+tx.vinfo(txid)                                  ->  /tx/{txid}/vinfo
+txs.trimmed()                                   ->  /txs/trimmed
 ```

--- a/pydecred/README.md
+++ b/pydecred/README.md
@@ -19,11 +19,11 @@ protocol, e.g. `https://explorer.dcrdata.org`. The available endpoints are gathe
 the server when the client is created. 
 
 ```
-from tinydecred.pydecred import DcrdataClient
+from tinydecred.pydecred.dcrdata import DcrdataClient
 import json
 
 client = DcrdataClient("https://explorer.dcrdata.org")
-bestBlock = client.block.best.get()
+bestBlock = client.block.best()
 print(json.dumps(bestBlock, indent=4, sort_keys=True))
 ``` 
 
@@ -49,25 +49,25 @@ blockhash = "00000000000000000fe92d4a057bd4425c5f58fa9b4d5b34b6f2b596ff01b3c9"
 txid = "355a6752539486503031d1a0bb62a3c53f83a4cad0765979510742b72b064f75"
 
 # /block/hash/{blockhash} - Get data for a block with it's hash.
-dumpResponse( client.block.hash.get(blockhash) )
+dumpResponse( client.block.hash(blockhash) )
 
 # /block/hash/{blockhash}/verbose - Same thing, but more info.
-dumpResponse( client.block.hash.verbose.get(blockhash) )
+dumpResponse( client.block.hash.verbose(blockhash) )
 
 # /block/range/{idx0}/{idx}/{step}/size - Get the size of every 10th block from 299900 to 300000.
 idx0 = 299900
 idx = 300000
 step = 10
-dumpResponse( client.block.range.size.get(idx0, idx, step) )
+dumpResponse( client.block.range.size(idx0, idx, step) )
 
 # /tx/{txid}/in/{txinoutindex} - Get a single input to a transaction
 txinoutindex = 0
-dumpResponse( tx.in.get(txid, txinoutindex) )
+dumpResponse( tx.__getattr__("in")(txid, txinoutindex) )
 
 # arguments can also be passed as keyword argument, in which case the 
 # order doesn't matter, but don't mix positional and keyword.
 thatOneBlock = "00000000000000000fe92d4a057bd4425c5f58fa9b4d5b34b6f2b596ff01b3c9"
-dumpResponse( client.block.hash.get(blockhash=thatOneBlock) )
+dumpResponse( client.block.hash(blockhash=thatOneBlock) )
 ```
 
 The dcrdata module includes websocket functionality as well. Subscribe to a 


### PR DESCRIPTION
Fix some of the examples in `pydecred/README.md`:

1. fix the `DcrdataClient` import path;

2. remove all `get` calls, they're not in the API;

3. work around the syntax error caused by trying to use the `in` language keyword
   in a dotted chain.