### PR TITLE
pydecred: remove config from nets module

### DIFF
--- a/util/chains.py
+++ b/util/chains.py
@@ -1,7 +1,4 @@
-from tinydecred import config
 from tinydecred.pydecred import account as dcracct, nets as dcrnets
-
-cfg = config.load()
 
 
 class BipIDs:


### PR DESCRIPTION
Must've snuck in during database work. Problematic and unneeded.