### PR TITLE
revocations: Store revocation txid in list

### DIFF
--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -1496,7 +1496,7 @@ class Account(object):
         revocableTickets = (
             utxo.txid for utxo in self.utxos.values() if utxo.isRevocableTicket()
         )
-        txs = (self.blockchain.tx(txid) for txid in revocableTickets)
+        txs = [self.blockchain.tx(txid) for txid in revocableTickets]
         for tx in txs:
             redeemHash = crypto.AddressScriptHash(
                 self.net.ScriptHashAddrID,


### PR DESCRIPTION
closes #62 

Using a generator causes problems when a revocation happens. Changing this to a list solves this.