### PR TITLE
tests: add html coverage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ examples/testnet
 decred/dist
 tinywallet/dist
 decred/poetry.lock
+htmlcov
 __pycache__/
 .pytest_cache
 .coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,8 @@ sure that the changes meet some minimum requirements. The action definition
 [file](./.github/workflows/python.yml) is a useful summary of the commands
 you'll run while developing.
 
-For test coverage see the `./decred/coverage-html.sh` script.
+For displaying line-by-line test coverage in a web browser see the
+`./decred/coverage-html.sh` script.
 
 ## More information
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ sure that the changes meet some minimum requirements. The action definition
 [file](./.github/workflows/python.yml) is a useful summary of the commands
 you'll run while developing.
 
+For test coverage see the `./decred/coverage-html.sh` script.
+
 ## More information
 
 Please find more information in the dcrd

--- a/decred/coverage-html.sh
+++ b/decred/coverage-html.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+## Change to this directory, then install the dependencies:
+# poetry install
+## The coverage report will be in the ./htmlcov/ directory.
+poetry run pytest --cov-config=.coveragerc --cov-report=html --cov=decred ./tests/

--- a/decred/coverage-html.sh
+++ b/decred/coverage-html.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-## Change to this directory, then install the dependencies:
+## To generate line-by-line test coverage viewable in a web browser,
+## change to this directory, then install the dependencies:
 # poetry install
 ## The coverage report will be in the ./htmlcov/ directory.
-poetry run pytest --cov-config=.coveragerc --cov-report=html --cov=decred ./tests/
+poetry run pytest --cov-report=html --cov=decred ./tests/

--- a/decred/pyproject.toml
+++ b/decred/pyproject.toml
@@ -31,6 +31,7 @@ websocket_client = "^0.57.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
+pytest-cov = "^2.8.1"
 pyflakes = "^2.1.1"
 black = "^19.10b0"
 


### PR DESCRIPTION
Add an easy way to get test coverage by using a pytest plugin. Part of #38.

- Add the `pytest-cov` plugin to `pyproject.toml` as a dev. dependency.
- Create the `./decred/coverage-html.sh` script to run tests and generate an HTML coverage report.
- Mention the script in the `CONTRIBUTING.md` doc.