### PR TITLE
tests: increase coverage

### DIFF
--- a/decred/.coveragerc
+++ b/decred/.coveragerc
@@ -2,7 +2,8 @@
 # https://coverage.readthedocs.io/en/latest/config.html
 
 [run]
-omit = tinydecred/tests/*
+omit = tests/*
+dynamic_context = test_function
 
 [report]
 # Regexes for lines to exclude from consideration
@@ -24,3 +25,6 @@ exclude_lines =
 ignore_errors = True
 # skip_covered = True
 skip_empty = True
+
+[html]
+show_contexts = True

--- a/decred/.coveragerc
+++ b/decred/.coveragerc
@@ -16,7 +16,7 @@ exclude_lines =
     if __name__ == .__main__.:
 
     # Don't complain if tests don't hit defensive assertion code.
-    assert
+    raise AssertionError
     raise NotImplementedError
     raise CrazyKeyError
     raise ParameterRangeError

--- a/decred/decred/crypto/crypto.py
+++ b/decred/decred/crypto/crypto.py
@@ -168,8 +168,8 @@ class AddressPubKeyHash:
 class AddressSecpPubKey:
     """
     AddressSecpPubKey represents an address, which is a pubkey hash and its
-    base-58 encoding. Argument pubkey should be a ByteArray corresponding to the
-    serializedCompressed public key (33 bytes).
+    base-58 encoding. Argument serializedPubkey should be a ByteArray
+    corresponding to the serializedCompressed public key (33 bytes).
     """
 
     def __init__(self, serializedPubkey, net):

--- a/decred/decred/crypto/crypto.py
+++ b/decred/decred/crypto/crypto.py
@@ -169,7 +169,7 @@ class AddressSecpPubKey:
     """
     AddressSecpPubKey represents an address, which is a pubkey hash and its
     base-58 encoding. Argument serializedPubkey should be a ByteArray
-    corresponding to the serializedCompressed public key (33 bytes).
+    corresponding to the serialized compressed public key (33 bytes).
     """
 
     def __init__(self, serializedPubkey, net):

--- a/decred/decred/dcr/nets.py
+++ b/decred/decred/dcr/nets.py
@@ -6,21 +6,16 @@ See LICENSE for details
 from . import mainnet, testnet, simnet
 
 
-mainnet = mainnet
-testnet = testnet
-simnet = simnet
+the_nets = {n.Name: n for n in (mainnet, testnet, simnet)}
 
 
 def parse(name):
     """
     Get the network parameters based on the network name.
-
-    Args:
-        acct (Account): An account with a properly set coinID and netID.
     """
     # Set testnet to DCR for now. If more coins are added, a better solution
     # will be needed.
-    for net in (mainnet, simnet, testnet):
-        if net.Name == name:
-            return net
-    raise Exception("unrecognized network name %s" % name)
+    try:
+        return the_nets[name]
+    except KeyError:
+        raise ValueError(f"unrecognized network name {name}")

--- a/decred/decred/dcr/wire/msgblock.py
+++ b/decred/decred/dcr/wire/msgblock.py
@@ -84,7 +84,7 @@ class BlockHeader:
         self.cachedH = None
 
     @staticmethod
-    def btcDecode(b, pver):  # io.Reader, pver uint32) error {
+    def btcDecode(b, pver):
         """
         BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
         This is part of the Message interface implementation.
@@ -149,14 +149,6 @@ class BlockHeader:
         return BlockHeader.deserialize(b)
 
     def btcEncode(self, pver):
-
-        #     sec := uint32(bh.Timestamp.Unix())
-        # return writeElements(w, bh.Version, &bh.PrevBlock, &bh.MerkleRoot,
-        #     &bh.StakeRoot, bh.VoteBits, bh.FinalState, bh.Voters,
-        #     bh.FreshStake, bh.Revocations, bh.PoolSize, bh.Bits, bh.SBits,
-        #     bh.Height, bh.Size, sec, bh.Nonce, bh.ExtraData,
-        #     bh.StakeVersion)
-
         # byte sizes
         int64 = 8
         int32 = uint32 = 4
@@ -203,18 +195,17 @@ class BlockHeader:
         i += extraDataSize
         b[i] = ByteArray(self.stakeVersion, length=uint32).littleEndian()
         i += uint32
-        if i != MaxHeaderSize:
-            raise ValueError(f"unexpected BlockHeader encoded size {i}")
         return b
 
     def hash(self):
         """
         hash computes the block identifier hash for the given block header.
+
+        Encode the header and hash256 everything prior to the number of
+        transactions.  Ignore the error returns since there is no way the
+        encode could fail except being out of memory which would cause a
+        run-time panic.
         """
-        # Encode the header and hash256 everything prior to the number of
-        # transactions.  Ignore the error returns since there is no way the
-        # encode could fail except being out of memory which would cause a
-        # run-time panic.
         return hashH(self.serialize().bytes())
 
     def cachedHash(self):

--- a/decred/decred/dcr/wire/msgblock.py
+++ b/decred/decred/dcr/wire/msgblock.py
@@ -194,17 +194,11 @@ class BlockHeader:
         b[i] = ByteArray(self.extraData, length=extraDataSize)
         i += extraDataSize
         b[i] = ByteArray(self.stakeVersion, length=uint32).littleEndian()
-        i += uint32
         return b
 
     def hash(self):
         """
         hash computes the block identifier hash for the given block header.
-
-        Encode the header and hash256 everything prior to the number of
-        transactions.  Ignore the error returns since there is no way the
-        encode could fail except being out of memory which would cause a
-        run-time panic.
         """
         return hashH(self.serialize().bytes())
 

--- a/decred/decred/dcr/wire/msgtx.py
+++ b/decred/decred/dcr/wire/msgtx.py
@@ -694,9 +694,7 @@ class MsgTx:
             # Read in the witnesses, and copy them into the already generated
             # by decodePrefix TxIns.
             if self.txIn is None or len(self.txIn) == 0:
-                self.txIn = [
-                    TxIn(None, 0) for i in range(count)
-                ]
+                self.txIn = [TxIn(None, 0) for i in range(count)]
             for txIn in self.txIn:
                 b = readTxInWitness(b, pver, self.version, txIn)
                 totalScriptSize += len(txIn.signatureScript)

--- a/decred/decred/dcr/wire/msgtx.py
+++ b/decred/decred/dcr/wire/msgtx.py
@@ -668,47 +668,27 @@ class MsgTx:
         return b, totalScriptSize
 
     def decodeWitness(self, b, pver, isFull):
-        # r io.Reader, pver uint32, isFull bool) (uint64, error) {
-        # Witness only; generate the TxIn list and fill out only the
-        # sigScripts.
+        """
+        Witness only; generate the TxIn list and fill out only the sigScripts.
+        """
         totalScriptSize = 0
-        if not isFull:
-            count = wire.readVarInt(b, pver)
+        count = wire.readVarInt(b, pver)
 
-            # Prevent more input transactions than could possibly fit into a
-            # message.  It would be possible to cause memory exhaustion and panics
-            # without a sane upper bound on this count.
-            if count > maxTxInPerMessage:
-                raise ValueError(
-                    "MsgTx.decodeWitness: too many input transactions to fit into"
-                    f" max message size [count {count}, max {maxTxInPerMessage}]"
-                )
-
-            self.txIn = [TxIn(None, 0) for i in range(count)]
-            for txIn in self.txIn:
-                b = readTxInWitness(b, pver, self.version, txIn)
-                totalScriptSize += len(txIn.signatureScript)
-            self.txOut = []
-        else:
-            # We're decoding witnesses from a full transaction, so read in
-            # the number of signature scripts, check to make sure it's the
-            # same as the number of TxIns we currently have, then fill in
-            # the signature scripts.
-            count = wire.readVarInt(b, pver)
-
+        # Prevent more input transactions than could possibly fit into a
+        # message, or memory exhaustion and panics could happen.
+        if count > maxTxInPerMessage:
+            raise ValueError(
+                "MsgTx.decodeWitness: too many input transactions to fit into"
+                f" max message size [count {count}, max {maxTxInPerMessage}]"
+            )
+        if isFull:
+            # We're decoding witnesses from a full transaction, so make sure
+            # the number of signature scripts is the same as the number of
+            # TxIns we currently have, then fill in the signature scripts.
             if count != len(self.txIn):
                 raise ValueError(
                     "MsgTx.decodeWitness: non equal witness and prefix txin"
                     f" quantities (witness {count}, prefix {len(self.txIn)})"
-                )
-
-            # Prevent more input transactions than could possibly fit into a
-            # message.  It would be possible to cause memory exhaustion and panics
-            # without a sane upper bound on this count.
-            if count > maxTxInPerMessage:
-                raise ValueError(
-                    "MsgTx.decodeWitness: too many input transactions to fit into"
-                    f" max message size [count {count}, max {maxTxInPerMessage}]"
                 )
 
             # Read in the witnesses, and copy them into the already generated
@@ -716,10 +696,16 @@ class MsgTx:
             if self.txIn is None or len(self.txIn) == 0:
                 self.txIn = [
                     TxIn(None, 0) for i in range(count)
-                ]  # := make([]TxIn, count)
+                ]
             for txIn in self.txIn:
                 b = readTxInWitness(b, pver, self.version, txIn)
                 totalScriptSize += len(txIn.signatureScript)
+        else:
+            self.txIn = [TxIn(None, 0) for i in range(count)]
+            for txIn in self.txIn:
+                b = readTxInWitness(b, pver, self.version, txIn)
+                totalScriptSize += len(txIn.signatureScript)
+            self.txOut = []
 
         return b, totalScriptSize
 

--- a/decred/decred/util/database.py
+++ b/decred/decred/util/database.py
@@ -80,7 +80,7 @@ class KeyValueDatabase:
             Bucket: The root bucket.
         """
         if "$" in name:
-            raise Exception("illegal character. '$' not allowed in table name")
+            raise ValueError("illegal character. '$' not allowed in table name")
         return Bucket(self.conn, name, **k)
 
     def close(self):
@@ -176,7 +176,7 @@ class Bucket:
                 constructor.
         """
         if "$" in name:
-            raise Exception("illegal character. '$' not allowed in table name")
+            raise ValueError("illegal character. '$' not allowed in table name")
         compoundName = "{parent}${child}".format(parent=self.name, child=name)
         return Bucket(self.conn, compoundName, **k)
 
@@ -212,7 +212,7 @@ class Bucket:
         cursor = self.conn.cursor()
         cursor.execute(self.existsQuery, (k,))
         row = cursor.fetchone()
-        if row is None:
+        if row is None:  # nocover
             return False
         return row[0] == 1
 
@@ -221,7 +221,7 @@ class Bucket:
         cursor = self.conn.cursor()
         cursor.execute(self.countQuery)
         row = cursor.fetchone()
-        if row is None:
+        if row is None:  # nocover
             return 0
         return row[0]
 

--- a/decred/decred/wallet/accounts.py
+++ b/decred/decred/wallet/accounts.py
@@ -6,7 +6,6 @@ See LICENSE for details
 accounts module
     Mostly account handling, interaction with this package's functions will
     mostly be through the AccountManager.
-    The tinycrypto package relies heavily on the lower-level crypto modules.
 """
 
 from decred.crypto import crypto

--- a/decred/tests/unit/crypto/test_crypto.py
+++ b/decred/tests/unit/crypto/test_crypto.py
@@ -205,7 +205,4 @@ class TestCrypto(unittest.TestCase):
         # Cannot serialize an empty private key.
         kpriv2 = crypto.ExtendedKey.new(testSeed)
         kpriv2.key.zero()
-        self.assertRaises(
-            ValueError,
-            kpriv2.serialize
-        )
+        self.assertRaises(ValueError, kpriv2.serialize)

--- a/decred/tests/unit/crypto/test_crypto.py
+++ b/decred/tests/unit/crypto/test_crypto.py
@@ -30,31 +30,37 @@ class TestCrypto(unittest.TestCase):
         self.assertTrue(a, aUnenc)
 
     def test_addr_secp_pubkey(self):
-        pairs = [
+        data = [
             (
                 "033b26959b2e1b0d88a050b111eeebcf776a38447f7ae5806b53c9b46e07c267ad",
                 "DkRKjw7LmGCSzBwaUtjQLfb75Zcx9hH8yGNs3qPSwVzZuUKs7iu2e",
+                "e201ee2f37bcc0ba0e93f82322e48333a92b9355",
             ),
             (
                 "0389ced3eaee84d5f0d0e166f6cd15f1bf6f429d1d13709393b418a6fb22d8be53",
                 "DkRLLaJWkmH75iZGtQYE6FEf16zxeHr6TCAF59tGxhds4MFc2HqUS",
+                "5643d59202de158b509544d40b32e85bfaf6243e",
             ),
             (
                 "02a14a0023d7d8cbc5d39fa60f7e4dc4d5bf18a7031f52875fbca6bf837f68713f",
                 "DkM3hdWuKSSTm7Vq8WZx5f294vcZbPkAQYBDswkjmF1CFuWCRYxTr",
+                "c5fa0d15266e055eaf8ec7c4d7a679885266ef0d",
             ),
             (
                 "03c3e3d7cde1c453a6283f5802a73d1cb3827cb4b007f58e3a52a36ce189934b6a",
                 "DkRLn9vzsjK4ZYgDKy7JVYHKGvpZU5CYGK9H8zF2VCWbpTyVsEf4P",
+                "73612f7b7b1ed32ff44dded7a2cf87c206fabf8a",
             ),
             (
                 "0254e17b230e782e591a9910794fdbf9943d500a47f2bf8446e1238f84e809bffc",
                 "DkM37ymaat9j6oTFii1MZVpXrc4aRLEMHhTZrvrz8QY6BZ2HX843L",
+                "a616bc09179e31e6d9e3abfcb16ac2d2baf45141",
             ),
         ]
-        for hexKey, addrStr in pairs:
+        for hexKey, addrStr, hash160 in data:
             addr = crypto.AddressSecpPubKey(ByteArray(hexKey), mainnet)
             self.assertEqual(addr.string(), addrStr)
+            self.assertEqual(addr.hash160().hex(), hash160)
 
     def test_addr_pubkey_hash(self):
         pairs = [
@@ -147,6 +153,12 @@ class TestCrypto(unittest.TestCase):
             kpub.key.hex(),
             "0317a47499fb2ef0ff8dc6133f577cd44a5f3e53d2835ae15359dbe80c41f70c9b",
         )
+        # Neutering again should make no difference.
+        kpub2 = kpub.neuter()
+        self.assertEqual(
+            kpub2.key.hex(),
+            "0317a47499fb2ef0ff8dc6133f577cd44a5f3e53d2835ae15359dbe80c41f70c9b",
+        )
         kpub_branch0 = kpub.child(0)
         self.assertEqual(
             kpub_branch0.key.hex(),
@@ -169,3 +181,31 @@ class TestCrypto(unittest.TestCase):
         )
         kpriv01_neutered = kpriv_branch0_child1.neuter()
         self.assertEqual(kpriv01_neutered.key.hex(), kpub_branch0_child1.key.hex())
+
+        # fmt: off
+        # Incorrect length of network version bytes.
+        self.assertRaises(
+            ValueError,
+            crypto.ExtendedKey,
+            # privVer too short.
+            ByteArray([0, 0, 0]),
+            ByteArray([0, 0, 0, 0]),
+            None, None, None, None, None, None, None
+        )
+        self.assertRaises(
+            ValueError,
+            crypto.ExtendedKey,
+            ByteArray([0, 0, 0, 0]),
+            # pubVer too long.
+            ByteArray([0, 0, 0, 0, 0]),
+            None, None, None, None, None, None, None
+        )
+        # fmt: on
+
+        # Cannot serialize an empty private key.
+        kpriv2 = crypto.ExtendedKey.new(testSeed)
+        kpriv2.key.zero()
+        self.assertRaises(
+            ValueError,
+            kpriv2.serialize
+        )

--- a/decred/tests/unit/dcr/test_nets.py
+++ b/decred/tests/unit/dcr/test_nets.py
@@ -1,0 +1,15 @@
+"""
+Copyright (c) 2019, the Decred developers
+See LICENSE for details
+"""
+
+import pytest
+
+from decred.dcr import mainnet, nets
+
+
+def test_nets():
+    assert nets.parse("mainnet") is mainnet
+
+    with pytest.raises(ValueError):
+        nets.parse("nonet")

--- a/decred/tests/unit/dcr/wire/test_msgblock.py
+++ b/decred/tests/unit/dcr/wire/test_msgblock.py
@@ -10,7 +10,7 @@ from decred.util.encode import ByteArray
 
 
 class TestBlockHeader(unittest.TestCase):
-    def test_decode(self):
+    def make_block_header(self):
         bh = msgblock.BlockHeader()
         bh.version = 6
         bh.prevBlock = reversed(
@@ -44,7 +44,6 @@ class TestBlockHeader(unittest.TestCase):
             "255221163779dfe8000000000000000000000000000000000000000000000000"
         )
         bh.stakeVersion = 0
-
         encoded = ByteArray(
             "060000000bd25508e99bf6f8399efce65762b55873d69dd05a7871631ac8fa7a36f1d05c"
             "977ea75040b905415cbc8f7dd519831a031ef5cd9c6a187a9eab8136c8b44fda00000000"
@@ -52,6 +51,10 @@ class TestBlockHeader(unittest.TestCase):
             "0000000000000000ffff7f20204e0000000000001b00000066010000aadd025d00000000"
             "255221163779dfe800000000000000000000000000000000000000000000000000000000"
         )
+        return bh, encoded
+
+    def test_decode(self):
+        bh, encoded = self.make_block_header()
         b = bh.serialize()
         self.assertEqual(b, encoded)
         reBH = msgblock.BlockHeader.unblob(b)
@@ -74,3 +77,9 @@ class TestBlockHeader(unittest.TestCase):
         self.assertEqual(bh.extraData, reBH.extraData)
         self.assertEqual(bh.stakeVersion, reBH.stakeVersion)
         self.assertEqual(bh.id(), reBH.id())
+
+    def test_cached_hash(self):
+        bh, _ = self.make_block_header()
+        self.assertIsNone(bh.cachedH)
+        hash_ = bh.cachedHash()
+        self.assertEqual(hash_, bh.cachedHash())

--- a/decred/tests/unit/dcr/wire/test_msgtx.py
+++ b/decred/tests/unit/dcr/wire/test_msgtx.py
@@ -429,7 +429,7 @@ class TestMsgTx(unittest.TestCase):
         #           i, err, test.writeErr)
         #       continue
         #   }
-        #
+
         #   # Deserialize the transaction.
         #   var tx MsgTx
         #   r := newFixedReader(test.max, test.buf)

--- a/decred/tests/unit/dcr/wire/test_msgtx.py
+++ b/decred/tests/unit/dcr/wire/test_msgtx.py
@@ -369,7 +369,7 @@ class TestMsgTx(unittest.TestCase):
             with self.assertRaises(Exception, msg="test %i" % i):
                 msgtx.MsgTx.btcDecode(buf, pver)
 
-    def test_tx_serialize_errors(self):  # TestTxSerializeErrors(t *testing.T) {
+    def test_tx_serialize_errors(self):
         """
         TestTxSerializeErrors performs negative tests against wire encode and decode
         of MsgTx to confirm error paths work correctly.
@@ -429,7 +429,7 @@ class TestMsgTx(unittest.TestCase):
         #           i, err, test.writeErr)
         #       continue
         #   }
-
+        #
         #   # Deserialize the transaction.
         #   var tx MsgTx
         #   r := newFixedReader(test.max, test.buf)
@@ -441,12 +441,27 @@ class TestMsgTx(unittest.TestCase):
 
     def test_tx(self):
         """
-        TestTx tests the MsgTx API.
-        This test is substantially truncated compare to it's counterpart in go
+        Substantially truncated compared to its counterpart in Go.
         """
+        msg = msgtx.MsgTx.new()
+
+        # Check the tx id.
+        self.assertEqual(
+            msg.id(), "bfc0e650ad0cc0dd5fa88b6bc84beb5ea4a675b4353671532796171ed319341b"
+        )
+
+        # Check the blob.
+        # fmt: off
+        self.assertEqual(
+            msgtx.MsgTx.blob(msg),
+            ByteArray(
+                [0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0]
+            ),
+        )
+        # fmt: on
+
         # Ensure the command is expected value.
         wantCmd = "tx"
-        msg = msgtx.MsgTx.new()
         self.assertEqual(msg.command(), wantCmd)
 
         # Ensure max payload is expected value for latest protocol version.
@@ -467,7 +482,7 @@ class TestMsgTx(unittest.TestCase):
             version=123,
             txIn=[
                 msgtx.TxIn(
-                    previousOutPoint=msgtx.OutPoint(txHash=newHash(), idx=5, tree=1,),
+                    previousOutPoint=msgtx.OutPoint(txHash=newHash(), idx=5, tree=1),
                     sequence=msgtx.MaxTxInSequenceNum,
                     valueIn=500,
                     blockHeight=111,
@@ -476,9 +491,9 @@ class TestMsgTx(unittest.TestCase):
                 ),
             ],
             txOut=[
-                msgtx.TxOut(value=321, pkScript=newHash(), version=0,),
-                msgtx.TxOut(value=654, pkScript=newHash(), version=0,),
-                msgtx.TxOut(value=987, pkScript=newHash(), version=0,),
+                msgtx.TxOut(value=321, pkScript=newHash(), version=0),
+                msgtx.TxOut(value=654, pkScript=newHash(), version=0),
+                msgtx.TxOut(value=987, pkScript=newHash(), version=0),
             ],
             lockTime=int(time.time()),
             expiry=int(time.time()) + 86400,
@@ -508,3 +523,31 @@ class TestMsgTx(unittest.TestCase):
             self.assertEqual(txOut.value, reTxOut.value)
             self.assertEqual(txOut.version, reTxOut.version)
             self.assertEqual(txOut.pkScript, reTxOut.pkScript)
+
+    def test_read_tx_in_prefix(self):
+        self.assertRaises(
+            ValueError,
+            msgtx.readTxInPrefix,
+            None,
+            None,
+            wire.TxSerializeOnlyWitness,
+            None,
+            None,
+        )
+
+    def test_read_script(self):
+        self.assertRaises(
+            ValueError,
+            msgtx.readScript,
+            ByteArray([0xFC]),
+            wire.ProtocolVersion,
+            0,
+            "Field",
+        )
+
+    def test_outpoint_txid(self):
+        outp = msgtx.OutPoint(txHash=None, idx=0, tree=0)
+        self.assertEqual(
+            outp.txid(),
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )

--- a/decred/tests/unit/dcr/wire/test_wire.py
+++ b/decred/tests/unit/dcr/wire/test_wire.py
@@ -14,10 +14,8 @@ class TestWire(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         helpers.prepareLogger("TestWire")
-
-    def test_write_read_var_int(self):
         # fmt: off
-        data = (
+        cls.data = (
             (0xFC,               [0xFC]),
             (0xFD,               [0xFD, 0xFD, 0x0]),
             (wire.MaxUint16,     [0xFD, 0xFF, 0xFF]),
@@ -27,7 +25,9 @@ class TestWire(unittest.TestCase):
             (wire.MaxUint64,     [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
         )
         # fmt: on
-        for val, bytes_ in data:
+
+    def test_write_var_int(self):
+        for val, bytes_ in self.data:
             from_val = wire.writeVarInt(wire.ProtocolVersion, val)
             from_bytes = ByteArray(bytes_)
             self.assertEqual(from_val, from_bytes)
@@ -36,4 +36,18 @@ class TestWire(unittest.TestCase):
         self.assertRaises(
             ValueError, wire.writeVarInt, wire.ProtocolVersion, wire.MaxUint64 + 1
         )
+
+    def test_read_var_int(self):
         self.assertEqual(wire.readVarInt(ByteArray([0xFC]), wire.ProtocolVersion), 0xFC)
+        self.assertRaises(
+            ValueError,
+            wire.readVarInt,
+            ByteArray([0xFE, 0xFF, 0xFF, 0x0, 0x0]),
+            wire.ProtocolVersion,
+        )
+        self.assertRaises(
+            ValueError,
+            wire.readVarInt,
+            ByteArray([0xFD, 0xFC, 0x0]),
+            wire.ProtocolVersion,
+        )

--- a/decred/tests/unit/util/test_database.py
+++ b/decred/tests/unit/util/test_database.py
@@ -4,12 +4,13 @@ See LICENSE for details
 """
 
 import os.path
-import unittest
 import random
 from tempfile import TemporaryDirectory
+import unittest
 
 from decred.util import database, helpers
 from decred.util.encode import ByteArray
+
 
 random.seed(0)
 randInt = random.randint
@@ -49,10 +50,13 @@ class TestDB(unittest.TestCase):
             master = database.KeyValueDatabase(os.path.join(tempDir, "tmp.sqlite"))
 
             # '$' in bucket name is illegal.
-            self.assertRaises(Exception, lambda: master.child("a$b"))
+            self.assertRaises(ValueError, lambda: master.child("a$b"))
 
             try:
                 db = master.child("test")
+
+                # '$' in bucket name is illegal.
+                self.assertRaises(ValueError, lambda: db.child("c$d"))
 
                 # Create some test data.
                 testPairs = [(randBytes(low=1), randBytes()) for _ in range(20)]

--- a/decred/tests/unit/util/test_encode.py
+++ b/decred/tests/unit/util/test_encode.py
@@ -77,7 +77,13 @@ class TestEncode(unittest.TestCase):
         z[2] = 255
         self.assertEqual(makeA(), z)
 
+        # encode.Blobber API
+        self.assertIsInstance(ByteArray.unblob(zero), ByteArray)
+        self.assertEqual(ByteArray.blob(zero), zero.b)
+
     def test_BuildyBytes(self):
+        self.assertEqual(BuildyBytes().hex(), "")
+
         d0 = ByteArray([0x01, 0x02])
         d1 = ByteArray([0x03, 0x04, 0x05])
         d2 = ByteArray(b"")


### PR DESCRIPTION
Part of #38.

Increase test coverage of various modules:

- `crypto/cripto.py`;
- `msgblock.py`, `msgtx.py` and `wire.py` in `dcr/wire`;
- `util/database.py`.

Additionally:

- make the HTML report show which tests exercise which lines of code;
- refactor the `dcr/nets.py` file and add a test for it;
- simplify the `MsgTx.decodeWitness` method in `dcr/wire/msgtx.py`;
- use `ValueError` in `util/database.py`.