### PR TITLE
Multi: sort import lines with the isort tool, and add it to both projects

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,9 +38,9 @@ jobs:
       working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |
         # stop the build if there are syntax errors or undefined names
-        poetry run flake8 --select=E9,F63,F7,F82 --show-source .
+        poetry run flake8 --select=E9,F63,F7,F82 --show-source -v .
         # exit-zero treats all errors as warnings
-        poetry run flake8 --ignore=E203,E221,E261,E731,W503 --exit-zero .
+        # poetry run flake8 --ignore=E203,E221,E261,E731,W503 --exit-zero .
     - name: Test the ${{ matrix.package }} package with pytest
       working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,7 +45,7 @@ jobs:
       working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |
         poetry run pytest ./tests/unit/
-    - name: Build the ${{ matrix.package }} package
-      working-directory: ${{ format('./{0}/', matrix.package) }}
-      run: |
-        poetry build
+    # - name: Build the ${{ matrix.package }} package
+    #   working-directory: ${{ format('./{0}/', matrix.package) }}
+    #   run: |
+    #     poetry build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Check, test and build both packages
 on: [push, pull_request]
 
 jobs:
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-
+        package: [decred, tinywallet]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -17,30 +17,35 @@ jobs:
     - name: Install pip
       run: |
         python -m pip install --upgrade pip
-    - name: Lint all code with black
-      run: |
-        pip install black
-        # stop the build if the code was not reformatted by black
-        black . --check
-    - name: Lint all code with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings
-        flake8 . --count --exit-zero  --ignore=E203,E221,E261,E731,W503 --max-complexity=10 --max-line-length=88 --statistics
     - name: Install the poetry tool
       run: |
         pip install poetry
-    - name: Install the decred package and its dependencies (including pytest)
-      working-directory: ./decred/
+    - name: Install the ${{ matrix.package }} package and its dependencies
+      working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |
         poetry install
-    - name: Test the decred package with pytest
-      working-directory: ./decred/
+    - name: Lint the ${{ matrix.package }} code with black
+      working-directory: ${{ format('./{0}/', matrix.package) }}
+      run: |
+        # stop the build if the code was not reformatted by black
+        poetry run black --check --diff .
+    - name: Sort ${{ matrix.package }} import lines with isort
+      working-directory: ${{ format('./{0}/', matrix.package) }}
+      run: |
+        # stop the build if import lines were not sorted by isort
+        poetry run isort --check-only --diff --recursive .
+    - name: Lint the ${{ matrix.package }} code with flake8
+      working-directory: ${{ format('./{0}/', matrix.package) }}
+      run: |
+        # stop the build if there are syntax errors or undefined names
+        poetry run flake8 --select=E9,F63,F7,F82 --show-source .
+        # exit-zero treats all errors as warnings
+        poetry run flake8 --ignore=E203,E221,E261,E731,W503 --exit-zero .
+    - name: Test the ${{ matrix.package }} package with pytest
+      working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |
         poetry run pytest ./tests/unit/
-    - name: Build the decred package
-      working-directory: ./decred/
+    - name: Build the ${{ matrix.package }} package
+      working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |
         poetry build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,13 +1,13 @@
-name: Check, test and build both packages
+name: Check and test both projects
 on: [push, pull_request]
 
 jobs:
-  build:
+  check-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        package: [decred, tinywallet]
+        project: [decred, tinywallet]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -20,32 +20,32 @@ jobs:
     - name: Install the poetry tool
       run: |
         pip install poetry
-    - name: Install the ${{ matrix.package }} package and its dependencies
-      working-directory: ${{ format('./{0}/', matrix.package) }}
+    - name: Install the ${{ matrix.project }} project and its dependencies
+      working-directory: ${{ format('./{0}/', matrix.project) }}
       run: |
         poetry install
-    - name: Lint the ${{ matrix.package }} code with black
-      working-directory: ${{ format('./{0}/', matrix.package) }}
+    - name: Lint the ${{ matrix.project }} code with black
+      working-directory: ${{ format('./{0}/', matrix.project) }}
       run: |
         # stop the build if the code was not reformatted by black
         poetry run black --check --diff .
-    - name: Sort ${{ matrix.package }} import lines with isort
-      working-directory: ${{ format('./{0}/', matrix.package) }}
+    - name: Sort ${{ matrix.project }} import lines with isort
+      working-directory: ${{ format('./{0}/', matrix.project) }}
       run: |
         # stop the build if import lines were not sorted by isort
         poetry run isort --check-only --diff --recursive .
-    - name: Lint the ${{ matrix.package }} code with flake8
-      working-directory: ${{ format('./{0}/', matrix.package) }}
+    - name: Lint the ${{ matrix.project }} code with flake8
+      working-directory: ${{ format('./{0}/', matrix.project) }}
       run: |
         # stop the build if there are syntax errors or undefined names
         poetry run flake8 --select=E9,F63,F7,F82 --show-source .
         # exit-zero treats all errors as warnings
         poetry run flake8 --ignore=E203,E221,E261,E731,W503 --exit-zero .
-    - name: Test the ${{ matrix.package }} package with pytest
-      working-directory: ${{ format('./{0}/', matrix.package) }}
+    - name: Test the ${{ matrix.project }} project with pytest
+      working-directory: ${{ format('./{0}/', matrix.project) }}
       run: |
         poetry run pytest ./tests/unit/
-    # - name: Build the ${{ matrix.package }} package
-    #   working-directory: ${{ format('./{0}/', matrix.package) }}
+    # - name: Build the ${{ matrix.project }} project
+    #   working-directory: ${{ format('./{0}/', matrix.project) }}
     #   run: |
     #     poetry build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,9 +38,9 @@ jobs:
       working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |
         # stop the build if there are syntax errors or undefined names
-        poetry run flake8 --select=E9,F63,F7,F82 --show-source -v .
+        poetry run flake8 --select=E9,F63,F7,F82 --show-source .
         # exit-zero treats all errors as warnings
-        # poetry run flake8 --ignore=E203,E221,E261,E731,W503 --exit-zero .
+        poetry run flake8 --ignore=E203,E221,E261,E731,W503 --exit-zero .
     - name: Test the ${{ matrix.package }} package with pytest
       working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |

--- a/decred/.flake8
+++ b/decred/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+count = True
+max-complexity = 10
+max-line-length = 88
+statistics = True
+exclude =
+    .git,
+    .venv,
+    .pytest_cache,
+    __pycache__

--- a/decred/decred/crypto/crypto.py
+++ b/decred/decred/crypto/crypto.py
@@ -9,14 +9,15 @@ Cryptographic functions.
 import hashlib
 import hmac
 
-from base58 import b58encode, b58decode
+from base58 import b58decode, b58encode
 from blake256.blake256 import blake_hash
 import nacl.secret
 
 from decred.util import encode
 from decred.util.encode import ByteArray
+
 from . import rando
-from .secp256k1.curve import curve as Curve, PublicKey, PrivateKey
+from .secp256k1.curve import PrivateKey, PublicKey, curve as Curve
 
 
 KEY_SIZE = 32

--- a/decred/decred/crypto/mnemonic.py
+++ b/decred/decred/crypto/mnemonic.py
@@ -7,6 +7,7 @@ PGP-based mnemonic seed generation.
 """
 
 from decred.util.encode import ByteArray
+
 from .crypto import sha256ChecksumByte
 
 

--- a/decred/decred/crypto/rando.py
+++ b/decred/decred/crypto/rando.py
@@ -6,6 +6,7 @@ See LICENSE for details
 
 import os
 
+
 MinSeedBytes = 16  # 128 bits
 MaxSeedBytes = 64  # 512 bits
 

--- a/decred/decred/crypto/secp256k1/curve.py
+++ b/decred/decred/crypto/secp256k1/curve.py
@@ -8,8 +8,9 @@ module curve
     dcrd golang version.
 """
 
-from decred.util.encode import ByteArray
 from decred.crypto.rando import generateSeed
+from decred.util.encode import ByteArray
+
 from .field import BytePoints, FieldVal
 
 

--- a/decred/decred/crypto/secp256k1/field.py
+++ b/decred/decred/crypto/secp256k1/field.py
@@ -8,6 +8,7 @@ from base64 import b64decode
 from zlib import decompress as zdecompress
 
 from decred.util.encode import ByteArray
+
 from .bytepoints import secp256k1BytePoints
 
 

--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -3,8 +3,9 @@ Copyright (c) 2019, Brian Stafford
 See LICENSE for details
 """
 
-from decred.crypto import opcode, crypto
+from decred.crypto import crypto, opcode
 from decred.util import encode, helpers
+
 from . import nets, txscript
 from .vsp import VotingServiceProvider
 

--- a/decred/decred/dcr/calc.py
+++ b/decred/decred/dcr/calc.py
@@ -9,6 +9,7 @@ import bisect
 import math
 
 from decred.util import helpers
+
 from . import constants as C
 from .nets import mainnet
 

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -14,13 +14,15 @@ import ssl
 import sys
 import threading
 import time
-from urllib.parse import urlparse, urlencode
+from urllib.parse import urlencode, urlparse
+
 import websocket
 
 from decred.crypto import crypto
 from decred.util import chains, database, encode, helpers, tinyhttp
 from decred.util.database import KeyValueDatabase
 from decred.wallet import api
+
 from . import account, calc, txscript
 from .wire import msgblock, msgtx, wire
 

--- a/decred/decred/dcr/nets/__init__.py
+++ b/decred/decred/dcr/nets/__init__.py
@@ -3,7 +3,7 @@ Copyright (c) 2019, The Decred developers
 See LICENSE for details
 """
 
-from . import mainnet, testnet, simnet
+from . import mainnet, simnet, testnet
 
 
 the_nets = {n.Name: n for n in (mainnet, testnet, simnet)}

--- a/decred/decred/dcr/rpc.py
+++ b/decred/decred/dcr/rpc.py
@@ -8,6 +8,7 @@ import ssl
 
 from decred.util import tinyhttp
 from decred.util.encode import ByteArray
+
 from .wire.msgblock import BlockHeader
 from .wire.msgtx import MsgTx
 

--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -12,6 +12,7 @@ from decred.crypto import crypto, opcode
 from decred.crypto.secp256k1.curve import curve as Curve
 from decred.util import helpers
 from decred.util.encode import ByteArray
+
 from .wire import msgtx, wire
 
 

--- a/decred/decred/dcr/vsp.py
+++ b/decred/decred/dcr/vsp.py
@@ -11,6 +11,7 @@ import time
 from decred.crypto import crypto
 from decred.util import encode, tinyhttp
 from decred.util.encode import ByteArray
+
 from . import constants, nets, txscript
 
 

--- a/decred/decred/dcr/wire/msgtx.py
+++ b/decred/decred/dcr/wire/msgtx.py
@@ -8,6 +8,7 @@ Based on dcrd MsgTx.
 
 from decred.crypto.crypto import hashH
 from decred.util.encode import ByteArray
+
 from . import wire
 
 

--- a/decred/decred/wallet/wallet.py
+++ b/decred/decred/wallet/wallet.py
@@ -10,6 +10,7 @@ from decred import config
 from decred.crypto import crypto, mnemonic, rando
 from decred.util import chains, encode, helpers
 from decred.util.database import KeyValueDatabase
+
 from . import accounts
 
 

--- a/decred/examples/plot_ticket_price.py
+++ b/decred/examples/plot_ticket_price.py
@@ -9,6 +9,7 @@ be installed separately with `pip3 install matplotlib`.
 from decred.dcr.dcrdata import DcrdataClient
 from decred.util.helpers import mktime
 
+
 try:
     from matplotlib import pyplot as plt
 except ImportError:

--- a/decred/pyproject.toml
+++ b/decred/pyproject.toml
@@ -32,7 +32,7 @@ websocket_client = "^0.57.0"
 [tool.poetry.dev-dependencies]
 pytest = "^5.3"
 pytest-cov = "^2.8"
-pyflakes = "^2.1"
+flake8 = "^3.7"
 black = "^19.10b0"
 isort = "^4.3"
 

--- a/decred/pyproject.toml
+++ b/decred/pyproject.toml
@@ -30,11 +30,30 @@ pynacl = "^1.3.0"
 websocket_client = "^0.57.0"
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.2"
-pytest-cov = "^2.8.1"
-pyflakes = "^2.1.1"
+pytest = "^5.3"
+pytest-cov = "^2.8"
+pyflakes = "^2.1"
 black = "^19.10b0"
+isort = "^4.3"
+
+[tool.isort]
+atomic = "true"
+combine_as_imports = "true"
+combine_star = "true"
+filter_files = "true"
+force_grid_wrap = 0
+force_sort_within_sections = "true"
+include_trailing_comma = "true"
+line_length = 88
+lines_after_imports = 2
+multi_line_output = 3
+use_parentheses = "true"
+virtual_env = "./.venv/"
+skip = [
+    "./examples/create_testnet_wallet.py",
+    "./examples/send_testnet.py"
+]
 
 [build-system]
-requires = ["poetry>=1.0.2"]
+requires = ["poetry>=1.0.3"]
 build-backend = "poetry.masonry.api"

--- a/decred/tests/benchmark/util/test_database_benchmark.py
+++ b/decred/tests/benchmark/util/test_database_benchmark.py
@@ -3,10 +3,11 @@ Copyright (c) 2019, the Decred developers
 See LICENSE for details
 """
 
-import pytest
 import os.path
 from tempfile import TemporaryDirectory
 import time
+
+import pytest
 
 from decred.util import database
 

--- a/decred/tests/integration/dcr/test_rpc.py
+++ b/decred/tests/integration/dcr/test_rpc.py
@@ -7,9 +7,9 @@ import os
 
 import pytest
 
+from decred.crypto import crypto, opcode
 from decred.dcr import rpc, txscript
 from decred.dcr.nets import mainnet
-from decred.crypto import crypto, opcode
 from decred.dcr.wire.msgblock import BlockHeader
 from decred.dcr.wire.msgtx import MsgTx
 from decred.util import helpers

--- a/decred/tests/unit/dcr/test_txscript.py
+++ b/decred/tests/unit/dcr/test_txscript.py
@@ -3,13 +3,13 @@ Copyright (c) 2019, the Decred developers
 See LICENSE for details
 """
 
-from base58 import b58decode
 import json
 import os
 from tempfile import TemporaryDirectory
 import time
 import unittest
 
+from base58 import b58decode
 
 from decred.crypto import crypto, opcode, rando
 from decred.crypto.secp256k1 import curve as Curve

--- a/tinywallet/.flake8
+++ b/tinywallet/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+count = True
+max-complexity = 10
+max-line-length = 88
+statistics = True
+exclude =
+    .git,
+    .venv,
+    .pytest_cache,
+    __pycache__

--- a/tinywallet/poetry.lock
+++ b/tinywallet/poetry.lock
@@ -94,13 +94,24 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "0.4.3"
 
 [[package]]
+category = "dev"
+description = "Code coverage measurement for Python"
+name = "coverage"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "5.0.3"
+
+[package.extras]
+toml = ["toml"]
+
+[[package]]
 category = "main"
 description = ""
 develop = true
 name = "decred"
 optional = false
 python-versions = "^3.6"
-version = "0.1.0"
+version = "0.0.1"
 
 [package.dependencies]
 appdirs = "^1.4.3"
@@ -112,7 +123,7 @@ websocket_client = "^0.57.0"
 [package.source]
 reference = ""
 type = "directory"
-url = "/home/nl/devel/decred/tinydecred/decred"
+url = "../decred"
 
 [[package]]
 category = "dev"
@@ -121,7 +132,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.4.0"
+version = "1.5.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -132,11 +143,25 @@ testing = ["packaging", "importlib-resources"]
 
 [[package]]
 category = "dev"
+description = "A Python utility / library to sort Python imports."
+name = "isort"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "4.3.21"
+
+[package.extras]
+pipfile = ["pipreqs", "requirementslib"]
+pyproject = ["toml"]
+requirements = ["pipreqs", "pip-api"]
+xdg_home = ["appdirs (>=1.4.0)"]
+
+[[package]]
+category = "dev"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
-version = "8.1.0"
+version = "8.2.0"
 
 [[package]]
 category = "dev"
@@ -239,7 +264,7 @@ description = "The sip module support for PyQt5"
 name = "pyqt5-sip"
 optional = false
 python-versions = ">=3.5"
-version = "12.7.0"
+version = "12.7.1"
 
 [[package]]
 category = "dev"
@@ -247,7 +272,7 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = ">=3.5"
-version = "5.3.4"
+version = "5.3.5"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
@@ -266,6 +291,21 @@ version = ">=0.12"
 [package.extras]
 checkqa-mypy = ["mypy (v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+category = "dev"
+description = "Pytest plugin for measuring coverage."
+name = "pytest-cov"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.8.1"
+
+[package.dependencies]
+coverage = ">=4.4"
+pytest = ">=3.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "virtualenv"]
 
 [[package]]
 category = "dev"
@@ -325,16 +365,14 @@ marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
-version = "2.0.1"
-
-[package.dependencies]
-more-itertools = "*"
+version = "2.1.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["jaraco.itertools"]
 
 [metadata]
-content-hash = "85190d6710709b08b6332d82d6803257c531cc9ce9bcbdf0afab9fafc5e47669"
+content-hash = "6400bc6601de3c89aff46da3ba3288f8d7d805bf18c5bda83f736c0289188ac7"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -404,14 +442,51 @@ colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
+coverage = [
+    {file = "coverage-5.0.3-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:cc1109f54a14d940b8512ee9f1c3975c181bbb200306c6d8b87d93376538782f"},
+    {file = "coverage-5.0.3-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:be18f4ae5a9e46edae3f329de2191747966a34a3d93046dbdf897319923923bc"},
+    {file = "coverage-5.0.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:3230d1003eec018ad4a472d254991e34241e0bbd513e97a29727c7c2f637bd2a"},
+    {file = "coverage-5.0.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:e69215621707119c6baf99bda014a45b999d37602cb7043d943c76a59b05bf52"},
+    {file = "coverage-5.0.3-cp27-cp27m-win32.whl", hash = "sha256:1daa3eceed220f9fdb80d5ff950dd95112cd27f70d004c7918ca6dfc6c47054c"},
+    {file = "coverage-5.0.3-cp27-cp27m-win_amd64.whl", hash = "sha256:51bc7710b13a2ae0c726f69756cf7ffd4362f4ac36546e243136187cfcc8aa73"},
+    {file = "coverage-5.0.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:9bea19ac2f08672636350f203db89382121c9c2ade85d945953ef3c8cf9d2a68"},
+    {file = "coverage-5.0.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:5012d3b8d5a500834783689a5d2292fe06ec75dc86ee1ccdad04b6f5bf231691"},
+    {file = "coverage-5.0.3-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:d513cc3db248e566e07a0da99c230aca3556d9b09ed02f420664e2da97eac301"},
+    {file = "coverage-5.0.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:3dbb72eaeea5763676a1a1efd9b427a048c97c39ed92e13336e726117d0b72bf"},
+    {file = "coverage-5.0.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:15cf13a6896048d6d947bf7d222f36e4809ab926894beb748fc9caa14605d9c3"},
+    {file = "coverage-5.0.3-cp35-cp35m-win32.whl", hash = "sha256:fca1669d464f0c9831fd10be2eef6b86f5ebd76c724d1e0706ebdff86bb4adf0"},
+    {file = "coverage-5.0.3-cp35-cp35m-win_amd64.whl", hash = "sha256:1e44a022500d944d42f94df76727ba3fc0a5c0b672c358b61067abb88caee7a0"},
+    {file = "coverage-5.0.3-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:b26aaf69713e5674efbde4d728fb7124e429c9466aeaf5f4a7e9e699b12c9fe2"},
+    {file = "coverage-5.0.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:722e4557c8039aad9592c6a4213db75da08c2cd9945320220634f637251c3894"},
+    {file = "coverage-5.0.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:7afad9835e7a651d3551eab18cbc0fdb888f0a6136169fbef0662d9cdc9987cf"},
+    {file = "coverage-5.0.3-cp36-cp36m-win32.whl", hash = "sha256:25dbf1110d70bab68a74b4b9d74f30e99b177cde3388e07cc7272f2168bd1477"},
+    {file = "coverage-5.0.3-cp36-cp36m-win_amd64.whl", hash = "sha256:c312e57847db2526bc92b9bfa78266bfbaabac3fdcd751df4d062cd4c23e46dc"},
+    {file = "coverage-5.0.3-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:a8b8ac7876bc3598e43e2603f772d2353d9931709345ad6c1149009fd1bc81b8"},
+    {file = "coverage-5.0.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:527b4f316e6bf7755082a783726da20671a0cc388b786a64417780b90565b987"},
+    {file = "coverage-5.0.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d649dc0bcace6fcdb446ae02b98798a856593b19b637c1b9af8edadf2b150bea"},
+    {file = "coverage-5.0.3-cp37-cp37m-win32.whl", hash = "sha256:cd60f507c125ac0ad83f05803063bed27e50fa903b9c2cfee3f8a6867ca600fc"},
+    {file = "coverage-5.0.3-cp37-cp37m-win_amd64.whl", hash = "sha256:c60097190fe9dc2b329a0eb03393e2e0829156a589bd732e70794c0dd804258e"},
+    {file = "coverage-5.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:d7008a6796095a79544f4da1ee49418901961c97ca9e9d44904205ff7d6aa8cb"},
+    {file = "coverage-5.0.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:ea9525e0fef2de9208250d6c5aeeee0138921057cd67fcef90fbed49c4d62d37"},
+    {file = "coverage-5.0.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c62a2143e1313944bf4a5ab34fd3b4be15367a02e9478b0ce800cb510e3bbb9d"},
+    {file = "coverage-5.0.3-cp38-cp38m-win32.whl", hash = "sha256:b0840b45187699affd4c6588286d429cd79a99d509fe3de0f209594669bb0954"},
+    {file = "coverage-5.0.3-cp38-cp38m-win_amd64.whl", hash = "sha256:76e2057e8ffba5472fd28a3a010431fd9e928885ff480cb278877c6e9943cc2e"},
+    {file = "coverage-5.0.3-cp39-cp39m-win32.whl", hash = "sha256:b63dd43f455ba878e5e9f80ba4f748c0a2156dde6e0e6e690310e24d6e8caf40"},
+    {file = "coverage-5.0.3-cp39-cp39m-win_amd64.whl", hash = "sha256:da93027835164b8223e8e5af2cf902a4c80ed93cb0909417234f4a9df3bcd9af"},
+    {file = "coverage-5.0.3.tar.gz", hash = "sha256:77afca04240c40450c331fa796b3eab6f1e15c5ecf8bf2b8bee9706cd5452fef"},
+]
 decred = []
 importlib-metadata = [
-    {file = "importlib_metadata-1.4.0-py2.py3-none-any.whl", hash = "sha256:bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359"},
-    {file = "importlib_metadata-1.4.0.tar.gz", hash = "sha256:f17c015735e1a88296994c0697ecea7e11db24290941983b08c9feb30921e6d8"},
+    {file = "importlib_metadata-1.5.0-py2.py3-none-any.whl", hash = "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"},
+    {file = "importlib_metadata-1.5.0.tar.gz", hash = "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302"},
+]
+isort = [
+    {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
+    {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.1.0.tar.gz", hash = "sha256:c468adec578380b6281a114cb8a5db34eb1116277da92d7c46f904f0b52d3288"},
-    {file = "more_itertools-8.1.0-py3-none-any.whl", hash = "sha256:1a2a32c72400d365000412fe08eb4a24ebee89997c18d3d147544f70f5403b39"},
+    {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},
+    {file = "more_itertools-8.2.0-py3-none-any.whl", hash = "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c"},
 ]
 packaging = [
     {file = "packaging-20.1-py2.py3-none-any.whl", hash = "sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73"},
@@ -470,27 +545,31 @@ pyqt5 = [
     {file = "PyQt5-5.12.3-5.12.6-cp35.cp36.cp37.cp38-none-win_amd64.whl", hash = "sha256:53d2183ab3edc1a2aa117a720dfd6cf81a9381911bd6a345290fc1a44daeb024"},
 ]
 pyqt5-sip = [
-    {file = "PyQt5_sip-12.7.0-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:1910c1cb5a388d4e59ebb2895d7015f360f3f6eeb1700e7e33e866c53137eb9e"},
-    {file = "PyQt5_sip-12.7.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b43ba2f18999d41c3df72f590348152e14cd4f6dcea2058c734d688dfb1ec61f"},
-    {file = "PyQt5_sip-12.7.0-cp35-cp35m-win32.whl", hash = "sha256:fabff832046643cdb93920ddaa8f77344df90768930fbe6bb33d211c4dcd0b5e"},
-    {file = "PyQt5_sip-12.7.0-cp35-cp35m-win_amd64.whl", hash = "sha256:8274ed50f4ffbe91d0f4cc5454394631edfecd75dc327aa01be8bc5818a57e88"},
-    {file = "PyQt5_sip-12.7.0-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:ef3c7a0bf78674b0dda86ff5809d8495019903a096c128e1f160984b37848f73"},
-    {file = "PyQt5_sip-12.7.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:3c330ff1f70b3eaa6f63dce9274df996dffea82ad9726aa8e3d6cbe38e986b2f"},
-    {file = "PyQt5_sip-12.7.0-cp36-cp36m-win32.whl", hash = "sha256:9047d887d97663790d811ac4e0d2e895f1bf2ecac4041691487de40c30239480"},
-    {file = "PyQt5_sip-12.7.0-cp36-cp36m-win_amd64.whl", hash = "sha256:9f6ab1417ecfa6c1ce6ce941e0cebc03e3ec9cd9925058043229a5f003ae5e40"},
-    {file = "PyQt5_sip-12.7.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:06bc66b50556fb949f14875a4c224423dbf03f972497ccb883fb19b7b7c3b346"},
-    {file = "PyQt5_sip-12.7.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:482a910fa73ee0e36c258d7646ef38f8061774bbc1765a7da68c65056b573341"},
-    {file = "PyQt5_sip-12.7.0-cp37-cp37m-win32.whl", hash = "sha256:1c7ad791ec86247f35243bbbdd29cd59989afbe0ab678e0a41211f4407f21dd8"},
-    {file = "PyQt5_sip-12.7.0-cp37-cp37m-win_amd64.whl", hash = "sha256:da69ba17f6ece9a85617743cb19de689f2d63025bf8001e2facee2ec9bcff18f"},
-    {file = "PyQt5_sip-12.7.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:02d94786bada670ab17a2b62ce95b3cf8e3b40c99d36007593a6334d551840bb"},
-    {file = "PyQt5_sip-12.7.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c3ab9ea1bc3f4ce8c57ebc66fb25cd044ef92ed1ca2afa3729854ecc59658905"},
-    {file = "PyQt5_sip-12.7.0-cp38-cp38-win32.whl", hash = "sha256:7695dfafb4f5549ce1290ae643d6508dfc2646a9003c989218be3ce42a1aa422"},
-    {file = "PyQt5_sip-12.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:091fbbe10a7aebadc0e8897a9449cda08d3c3f663460d812eca3001ca1ed3526"},
-    {file = "PyQt5_sip-12.7.0.tar.gz", hash = "sha256:0a067ade558befe4d46335b13d8b602b5044363bfd601419b556d4ec659bca18"},
+    {file = "PyQt5_sip-12.7.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:f314f31f5fd39b06897f013f425137e511d45967150eb4e424a363d8138521c6"},
+    {file = "PyQt5_sip-12.7.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b42021229424aa44e99b3b49520b799fd64ff6ae8b53f79f903bbd85719a28e4"},
+    {file = "PyQt5_sip-12.7.1-cp35-cp35m-win32.whl", hash = "sha256:6b4860c4305980db509415d0af802f111d15f92016c9422eb753bc8883463456"},
+    {file = "PyQt5_sip-12.7.1-cp35-cp35m-win_amd64.whl", hash = "sha256:d46b0f8effc554de52a1466b1bd80e5cb4bce635a75ac4e7ad6247c965dec5b9"},
+    {file = "PyQt5_sip-12.7.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:3f665376d9e52faa9855c3736a66ce6d825f85c86d7774d3c393f09da23f4f86"},
+    {file = "PyQt5_sip-12.7.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1115728644bbadcde5fc8a16e7918bd31915a42dd6fb36b10d4afb78c582753e"},
+    {file = "PyQt5_sip-12.7.1-cp36-cp36m-win32.whl", hash = "sha256:cbeeae6b45234a1654657f79943f8bccd3d14b4e7496746c62cf6fbce69442c7"},
+    {file = "PyQt5_sip-12.7.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8da842d3d7bf8931d1093105fb92702276b6dbb7e801abbaaa869405d616171a"},
+    {file = "PyQt5_sip-12.7.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1f4289276d355b6521dc2cc956189315da6f13adfb6bbab8f25ebd15e3bce1d4"},
+    {file = "PyQt5_sip-12.7.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c1e730a9eb2ec3869ed5d81b0f99f6e2460fb4d77750444c0ec183b771d798f7"},
+    {file = "PyQt5_sip-12.7.1-cp37-cp37m-win32.whl", hash = "sha256:b5b4906445fe980aee76f20400116b6904bf5f30d0767489c13370e42a764020"},
+    {file = "PyQt5_sip-12.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7ffa39763097f64de129cf5cc770a651c3f65d2466b4fe05bef2bd2efbaa38e6"},
+    {file = "PyQt5_sip-12.7.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:288c6dc18a8d6a20981c07b715b5695d9b66880778565f3792bc6e38f14f20fb"},
+    {file = "PyQt5_sip-12.7.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ee1a12f09d5af2304273bfd2f6b43835c1467d5ed501a6c95f5405637fa7750a"},
+    {file = "PyQt5_sip-12.7.1-cp38-cp38-win32.whl", hash = "sha256:8a18e6f45d482ddfe381789979d09ee13aa6450caa3a0476503891bccb3ac709"},
+    {file = "PyQt5_sip-12.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:e28c3abc9b62a1b7e796891648b9f14f8167b31c8e7990fae79654777252bb4d"},
+    {file = "PyQt5_sip-12.7.1.tar.gz", hash = "sha256:e6078f5ee7d31c102910d0c277a110e1c2a20a3fc88cd017a39e170120586d3f"},
 ]
 pytest = [
-    {file = "pytest-5.3.4-py3-none-any.whl", hash = "sha256:c13d1943c63e599b98cf118fcb9703e4d7bde7caa9a432567bcdcae4bf512d20"},
-    {file = "pytest-5.3.4.tar.gz", hash = "sha256:1d122e8be54d1a709e56f82e2d85dcba3018313d64647f38a91aec88c239b600"},
+    {file = "pytest-5.3.5-py3-none-any.whl", hash = "sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"},
+    {file = "pytest-5.3.5.tar.gz", hash = "sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d"},
+]
+pytest-cov = [
+    {file = "pytest-cov-2.8.1.tar.gz", hash = "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b"},
+    {file = "pytest_cov-2.8.1-py2.py3-none-any.whl", hash = "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"},
 ]
 regex = [
     {file = "regex-2020.1.8-cp27-cp27m-win32.whl", hash = "sha256:4e8f02d3d72ca94efc8396f8036c0d3bcc812aefc28ec70f35bb888c74a25161"},
@@ -556,6 +635,6 @@ websocket-client = [
     {file = "websocket_client-0.57.0.tar.gz", hash = "sha256:d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010"},
 ]
 zipp = [
-    {file = "zipp-2.0.1-py3-none-any.whl", hash = "sha256:e013e7800f60ec4dde789ebf4e9f7a54236e4bbf5df2a1a4e20ce9e1d9609d67"},
-    {file = "zipp-2.0.1.tar.gz", hash = "sha256:b338014b9bc7102ca69e0fb96ed07215a8954d2989bc5d83658494ab2ba634af"},
+    {file = "zipp-2.1.0-py3-none-any.whl", hash = "sha256:ccc94ed0909b58ffe34430ea5451f07bc0c76467d7081619a454bf5c98b89e28"},
+    {file = "zipp-2.1.0.tar.gz", hash = "sha256:feae2f18633c32fc71f2de629bfb3bd3c9325cd4419642b1f1da42ee488d9b98"},
 ]

--- a/tinywallet/poetry.lock
+++ b/tinywallet/poetry.lock
@@ -71,7 +71,7 @@ description = "Foreign Function Interface for Python calling C code."
 name = "cffi"
 optional = false
 python-versions = "*"
-version = "1.13.2"
+version = "1.14.0"
 
 [package.dependencies]
 pycparser = "*"
@@ -127,6 +127,28 @@ url = "../decred"
 
 [[package]]
 category = "dev"
+description = "Discover and load entry points from installed packages."
+name = "entrypoints"
+optional = false
+python-versions = ">=2.7"
+version = "0.3"
+
+[[package]]
+category = "dev"
+description = "the modular source code checker: pep8, pyflakes and co"
+name = "flake8"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.7.9"
+
+[package.dependencies]
+entrypoints = ">=0.3.0,<0.4.0"
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.5.0,<2.6.0"
+pyflakes = ">=2.1.0,<2.2.0"
+
+[[package]]
+category = "dev"
 description = "Read metadata from Python packages"
 marker = "python_version < \"3.8\""
 name = "importlib-metadata"
@@ -154,6 +176,14 @@ pipfile = ["pipreqs", "requirementslib"]
 pyproject = ["toml"]
 requirements = ["pipreqs", "pip-api"]
 xdg_home = ["appdirs (>=1.4.0)"]
+
+[[package]]
+category = "dev"
+description = "McCabe checker, plugin for flake8"
+name = "mccabe"
+optional = false
+python-versions = "*"
+version = "0.6.1"
 
 [[package]]
 category = "dev"
@@ -206,6 +236,14 @@ name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.8.1"
+
+[[package]]
+category = "dev"
+description = "Python style guide checker"
+name = "pycodestyle"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.5.0"
 
 [[package]]
 category = "main"
@@ -372,7 +410,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools"]
 
 [metadata]
-content-hash = "6400bc6601de3c89aff46da3ba3288f8d7d805bf18c5bda83f736c0289188ac7"
+content-hash = "c4da4e6af2c8379308b9c3dee925c94b3a12f9d00d1e4375993676629f3573c4"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -400,39 +438,34 @@ blake256 = [
     {file = "blake256-0.1.1.tar.gz", hash = "sha256:802945f2f07454d726fd0b0ee5c54dd133d686cb6f05b3d85af2d55ac17075f5"},
 ]
 cffi = [
-    {file = "cffi-1.13.2-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43"},
-    {file = "cffi-1.13.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396"},
-    {file = "cffi-1.13.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54"},
-    {file = "cffi-1.13.2-cp27-cp27m-win32.whl", hash = "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159"},
-    {file = "cffi-1.13.2-cp27-cp27m-win_amd64.whl", hash = "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97"},
-    {file = "cffi-1.13.2-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579"},
-    {file = "cffi-1.13.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc"},
-    {file = "cffi-1.13.2-cp34-cp34m-macosx_10_6_intel.whl", hash = "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f"},
-    {file = "cffi-1.13.2-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858"},
-    {file = "cffi-1.13.2-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42"},
-    {file = "cffi-1.13.2-cp34-cp34m-win32.whl", hash = "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b"},
-    {file = "cffi-1.13.2-cp34-cp34m-win_amd64.whl", hash = "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20"},
-    {file = "cffi-1.13.2-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3"},
-    {file = "cffi-1.13.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25"},
-    {file = "cffi-1.13.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5"},
-    {file = "cffi-1.13.2-cp35-cp35m-win32.whl", hash = "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c"},
-    {file = "cffi-1.13.2-cp35-cp35m-win_amd64.whl", hash = "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b"},
-    {file = "cffi-1.13.2-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04"},
-    {file = "cffi-1.13.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652"},
-    {file = "cffi-1.13.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57"},
-    {file = "cffi-1.13.2-cp36-cp36m-win32.whl", hash = "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e"},
-    {file = "cffi-1.13.2-cp36-cp36m-win_amd64.whl", hash = "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"},
-    {file = "cffi-1.13.2-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410"},
-    {file = "cffi-1.13.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a"},
-    {file = "cffi-1.13.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12"},
-    {file = "cffi-1.13.2-cp37-cp37m-win32.whl", hash = "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e"},
-    {file = "cffi-1.13.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a"},
-    {file = "cffi-1.13.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d"},
-    {file = "cffi-1.13.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3"},
-    {file = "cffi-1.13.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db"},
-    {file = "cffi-1.13.2-cp38-cp38-win32.whl", hash = "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506"},
-    {file = "cffi-1.13.2-cp38-cp38-win_amd64.whl", hash = "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba"},
-    {file = "cffi-1.13.2.tar.gz", hash = "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346"},
+    {file = "cffi-1.14.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384"},
+    {file = "cffi-1.14.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:cf16e3cf6c0a5fdd9bc10c21687e19d29ad1fe863372b5543deaec1039581a30"},
+    {file = "cffi-1.14.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:f2b0fa0c01d8a0c7483afd9f31d7ecf2d71760ca24499c8697aeb5ca37dc090c"},
+    {file = "cffi-1.14.0-cp27-cp27m-win32.whl", hash = "sha256:99f748a7e71ff382613b4e1acc0ac83bf7ad167fb3802e35e90d9763daba4d78"},
+    {file = "cffi-1.14.0-cp27-cp27m-win_amd64.whl", hash = "sha256:c420917b188a5582a56d8b93bdd8e0f6eca08c84ff623a4c16e809152cd35793"},
+    {file = "cffi-1.14.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:399aed636c7d3749bbed55bc907c3288cb43c65c4389964ad5ff849b6370603e"},
+    {file = "cffi-1.14.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:cab50b8c2250b46fe738c77dbd25ce017d5e6fb35d3407606e7a4180656a5a6a"},
+    {file = "cffi-1.14.0-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:001bf3242a1bb04d985d63e138230802c6c8d4db3668fb545fb5005ddf5bb5ff"},
+    {file = "cffi-1.14.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:e56c744aa6ff427a607763346e4170629caf7e48ead6921745986db3692f987f"},
+    {file = "cffi-1.14.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b8c78301cefcf5fd914aad35d3c04c2b21ce8629b5e4f4e45ae6812e461910fa"},
+    {file = "cffi-1.14.0-cp35-cp35m-win32.whl", hash = "sha256:8c0ffc886aea5df6a1762d0019e9cb05f825d0eec1f520c51be9d198701daee5"},
+    {file = "cffi-1.14.0-cp35-cp35m-win_amd64.whl", hash = "sha256:8a6c688fefb4e1cd56feb6c511984a6c4f7ec7d2a1ff31a10254f3c817054ae4"},
+    {file = "cffi-1.14.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:95cd16d3dee553f882540c1ffe331d085c9e629499ceadfbda4d4fde635f4b7d"},
+    {file = "cffi-1.14.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66e41db66b47d0d8672d8ed2708ba91b2f2524ece3dee48b5dfb36be8c2f21dc"},
+    {file = "cffi-1.14.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:028a579fc9aed3af38f4892bdcc7390508adabc30c6af4a6e4f611b0c680e6ac"},
+    {file = "cffi-1.14.0-cp36-cp36m-win32.whl", hash = "sha256:cef128cb4d5e0b3493f058f10ce32365972c554572ff821e175dbc6f8ff6924f"},
+    {file = "cffi-1.14.0-cp36-cp36m-win_amd64.whl", hash = "sha256:337d448e5a725bba2d8293c48d9353fc68d0e9e4088d62a9571def317797522b"},
+    {file = "cffi-1.14.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e577934fc5f8779c554639376beeaa5657d54349096ef24abe8c74c5d9c117c3"},
+    {file = "cffi-1.14.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:62ae9af2d069ea2698bf536dcfe1e4eed9090211dbaafeeedf5cb6c41b352f66"},
+    {file = "cffi-1.14.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:14491a910663bf9f13ddf2bc8f60562d6bc5315c1f09c704937ef17293fb85b0"},
+    {file = "cffi-1.14.0-cp37-cp37m-win32.whl", hash = "sha256:c43866529f2f06fe0edc6246eb4faa34f03fe88b64a0a9a942561c8e22f4b71f"},
+    {file = "cffi-1.14.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2089ed025da3919d2e75a4d963d008330c96751127dd6f73c8dc0c65041b4c26"},
+    {file = "cffi-1.14.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3b911c2dbd4f423b4c4fcca138cadde747abdb20d196c4a48708b8a2d32b16dd"},
+    {file = "cffi-1.14.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:7e63cbcf2429a8dbfe48dcc2322d5f2220b77b2e17b7ba023d6166d84655da55"},
+    {file = "cffi-1.14.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:3d311bcc4a41408cf5854f06ef2c5cab88f9fded37a3b95936c9879c1640d4c2"},
+    {file = "cffi-1.14.0-cp38-cp38-win32.whl", hash = "sha256:675686925a9fb403edba0114db74e741d8181683dcf216be697d208857e04ca8"},
+    {file = "cffi-1.14.0-cp38-cp38-win_amd64.whl", hash = "sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b"},
+    {file = "cffi-1.14.0.tar.gz", hash = "sha256:2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6"},
 ]
 click = [
     {file = "Click-7.0-py2.py3-none-any.whl", hash = "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13"},
@@ -476,6 +509,14 @@ coverage = [
     {file = "coverage-5.0.3.tar.gz", hash = "sha256:77afca04240c40450c331fa796b3eab6f1e15c5ecf8bf2b8bee9706cd5452fef"},
 ]
 decred = []
+entrypoints = [
+    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
+    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
+]
+flake8 = [
+    {file = "flake8-3.7.9-py2.py3-none-any.whl", hash = "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"},
+    {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
+]
 importlib-metadata = [
     {file = "importlib_metadata-1.5.0-py2.py3-none-any.whl", hash = "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"},
     {file = "importlib_metadata-1.5.0.tar.gz", hash = "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302"},
@@ -483,6 +524,10 @@ importlib-metadata = [
 isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
     {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 more-itertools = [
     {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},
@@ -503,6 +548,10 @@ pluggy = [
 py = [
     {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
     {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.5.0-py2.py3-none-any.whl", hash = "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56"},
+    {file = "pycodestyle-2.5.0.tar.gz", hash = "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"},
 ]
 pycparser = [
     {file = "pycparser-2.19.tar.gz", hash = "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"},

--- a/tinywallet/pyproject.toml
+++ b/tinywallet/pyproject.toml
@@ -29,13 +29,29 @@ decred = {path = "../decred/"}
 pyqt5 = "=5.12.3"
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.2"
+pytest = "^5.3.5"
+pytest-cov = "^2.8.1"
 pyflakes = "^2.1.1"
 black = "^19.10b0"
+isort = "^4.3.21"
 
 [tool.poetry.scripts]
 tinywallet = "tinywallet.app:main"
 
+[tool.isort]
+atomic = "true"
+combine_as_imports = "true"
+combine_star = "true"
+filter_files = "true"
+force_grid_wrap = 0
+force_sort_within_sections = "true"
+include_trailing_comma = "true"
+line_length = 88
+lines_after_imports = 2
+multi_line_output = 3
+use_parentheses = "true"
+virtual_env = "./.venv/"
+
 [build-system]
-requires = ["poetry>=1.0.2"]
+requires = ["poetry>=1.0.3"]
 build-backend = "poetry.masonry.api"

--- a/tinywallet/pyproject.toml
+++ b/tinywallet/pyproject.toml
@@ -31,7 +31,7 @@ pyqt5 = "=5.12.3"
 [tool.poetry.dev-dependencies]
 pytest = "^5.3.5"
 pytest-cov = "^2.8.1"
-pyflakes = "^2.1.1"
+flake8 = "^3.7.9"
 black = "^19.10b0"
 isort = "^4.3.21"
 

--- a/tinywallet/tests/unit/no_tests_yet.py
+++ b/tinywallet/tests/unit/no_tests_yet.py
@@ -1,3 +1,0 @@
-"""
-Placeholder to make CI happy. One day there'll be actual tests here...
-"""

--- a/tinywallet/tests/unit/no_tests_yet.py
+++ b/tinywallet/tests/unit/no_tests_yet.py
@@ -1,0 +1,3 @@
+"""
+Placeholder to make CI happy. One day there'll be actual tests here...
+"""

--- a/tinywallet/tests/unit/test_placeholder.py
+++ b/tinywallet/tests/unit/test_placeholder.py
@@ -1,0 +1,11 @@
+"""
+Copyright (c) 2020, the Decred developers
+See LICENSE for details
+"""
+
+
+def test_placeholder():
+    """
+    Placeholder to make CI happy. One day there'll be actual tests here...
+    """
+    assert True

--- a/tinywallet/tinywallet/app.py
+++ b/tinywallet/tinywallet/app.py
@@ -9,15 +9,14 @@ A PyQt light wallet.
 import os
 import sys
 
-from PyQt5 import QtGui, QtCore, QtWidgets
+from PyQt5 import QtCore, QtGui, QtWidgets
 
 from decred import config
 from decred.dcr import constants as DCR
 from decred.dcr.dcrdata import DcrdataBlockchain
-from decred.util import helpers, database
+from decred.util import database, helpers
 from decred.wallet.wallet import Wallet
-
-from tinywallet import screens, ui, qutilities as Q
+from tinywallet import qutilities as Q, screens, ui
 
 
 # the directory of the tinywallet package

--- a/tinywallet/tinywallet/mpl.py
+++ b/tinywallet/tinywallet/mpl.py
@@ -7,14 +7,13 @@ See LICENSE for details
 import os
 import time
 
+from decred.dcr import constants as C
+from decred.util import helpers
 import matplotlib
 from matplotlib import font_manager as FontManager
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 (flake8 ignore)
-
-from decred.dcr import constants as C
-from decred.util import helpers
 
 from . import ui as UI
 

--- a/tinywallet/tinywallet/qutilities.py
+++ b/tinywallet/tinywallet/qutilities.py
@@ -8,7 +8,7 @@ PyQt5 utilities.
 
 import re
 
-from PyQt5 import QtCore, QtWidgets, QtGui
+from PyQt5 import QtCore, QtGui, QtWidgets
 
 from decred.util import helpers
 

--- a/tinywallet/tinywallet/screens.py
+++ b/tinywallet/tinywallet/screens.py
@@ -9,12 +9,12 @@ import random
 import time
 from urllib.parse import urlparse
 
-from PyQt5 import QtGui, QtCore, QtWidgets
+from PyQt5 import QtCore, QtGui, QtWidgets
 
 from decred import config
 from decred.dcr import constants as DCR
 from decred.dcr.vsp import VotingServiceProvider
-from decred.util import helpers, chains
+from decred.util import chains, helpers
 from decred.wallet.wallet import Wallet
 
 from . import qutilities as Q, ui


### PR DESCRIPTION
This changeset adds the [isort](https://timothycrosley.github.io/isort/) tool to the project. It [groups and sorts](https://timothycrosley.github.io/isort/#how-does-isort-work) the import lines in each Python file.

The following changes are included:

- create a good isort configuration that doesn't conflict with black, adding it to both projects' `pyproject.toml` files;

The isort default conflicts with black, so that running both tools does not converge to a stable state: the included settings avoid this problem. The tool supports storing its config in the `pyproject.toml` file, avoiding adding yet another config file.

- add isort as a dev dependency in both projects;

This is needed so that the tool is available to both Github actions and manual usage.

- apply isort to both projects' code;

Both codebases are updated using the tool.

- adjust the Github workflow file so that six overall jobs are created: one for each project multiplied by one for each of three Python versions;

Until now the black and flake8 tools have been installed outside the projects' virtual environment, and each of them run only once over all the code. However isort, since its config is in `pyproject.toml`, has to be run inside each virtualenv. Rather than creating two very similar jobs for the two project, another dimension is added to the workflow matrix, parameterized on the project name: this way six parallel jobs are created.

- update dependencies in both projects (only the `tinywallet`'s `poetry.lock` file is committed);

From time to time the dependencies should be updated, and this seems like a good time. The `decred` dependency versions are relaxed a bit to allow more flexibility, while the ones in `tinywallet` are kept strict and that, in addition to committing its `poetry.lock` file, allows reproducible builds.

- increase the required poetry version to 1.0.3 in both projects;

Version 1.0.3 of poetry ~~fixes~~ was supposed to fix a [bug](https://github.com/python-poetry/poetry/issues/1757#issuecomment-576280586) that prevented referring to the local `decred` code while building the `tinywallet` project.

EDIT: unfortunately the bug is still there, so I'm skipping package building in the Github action for now.

- add `.flake8` config files to both projects.

We were running flake8 (and black) before creating virtual environments with poetry, but now we run all commands inside virtualenvs, so we need to exclude the `.venv` directory in the flake8 configuration. Unfortunately flake8 does not support storing its configuration in `pyproject.toml`, so we do have to add new files for it.