### PR TITLE
Add a test for DcrdataPath, and HTTP monkeypatching fixtures.

### DIFF
--- a/decred/tests/unit/dcr/conftest.py
+++ b/decred/tests/unit/dcr/conftest.py
@@ -19,18 +19,15 @@ def http_get_post(monkeypatch):
     q = {}
 
     def mock_get(uri, **kwargs):
-        nonlocal q
         return q[uri].pop()
 
     def mock_post(uri, data, **kwargs):
-        nonlocal q
         return q[(uri, repr(data))].pop()
 
     monkeypatch.setattr(tinyhttp, "get", mock_get)
     monkeypatch.setattr(tinyhttp, "post", mock_post)
 
     def queue(k, v):
-        nonlocal q
         q.setdefault(k, []).append(v)
 
     return queue

--- a/decred/tests/unit/dcr/conftest.py
+++ b/decred/tests/unit/dcr/conftest.py
@@ -9,32 +9,28 @@ from decred.util import tinyhttp
 
 
 @pytest.fixture
-def http_get(request, monkeypatch):
+def http_get_post(monkeypatch):
     """
-    Use this fixture in tests while defining the responses to be returned in
-    a "HTTP_GET_RESP" function-level dict with "uri" as keys.
+    Tests will use the returned "queue" function to add responses they want
+    returned from both tinyhttp "get" and "post" functions.
+    The "get" responses will use "uri" as a key, while the "post" responses
+    will use "(uri, repr(data))".
     """
-    get_resp = getattr(request.function, "HTTP_GET_RESP")
+    q = {}
 
     def mock_get(uri, **kwargs):
-        nonlocal get_resp
-        return get_resp[uri]
-
-    # Avoid calling the actual tinyhttp.get .
-    monkeypatch.setattr(tinyhttp, "get", mock_get)
-
-
-@pytest.fixture
-def http_post(request, monkeypatch):
-    """
-    Use this fixture in tests while defining the responses to be returned in
-    a "HTTP_POST_RESP" function-level dict with "(uri, repr(data))" as keys.
-    """
-    post_resp = getattr(request.function, "HTTP_POST_RESP")
+        nonlocal q
+        return q[uri].pop()
 
     def mock_post(uri, data, **kwargs):
-        nonlocal post_resp
-        return post_resp[(uri, repr(data))]
+        nonlocal q
+        return q[(uri, repr(data))].pop()
 
-    # Avoid calling the actual tinyhttp.post .
+    monkeypatch.setattr(tinyhttp, "get", mock_get)
     monkeypatch.setattr(tinyhttp, "post", mock_post)
+
+    def queue(k, v):
+        nonlocal q
+        q.setdefault(k, []).append(v)
+
+    return queue

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -8,7 +8,7 @@ import pytest
 from decred.dcr import dcrdata
 
 
-def test_dcrdatapath(http_post):
+def test_dcrdatapath(http_get_post):
     ddp = dcrdata.DcrdataPath()
 
     # __getattr__
@@ -29,12 +29,7 @@ def test_dcrdatapath(http_post):
     csp = ddp.getCallsignPath("address", address="1234")
     assert csp == "/address?address=1234"
 
-    # Post.
-    ret = ddp.post("")
+    # Post. Queue the response we want first.
+    http_get_post(("", "'data'"), {})
+    ret = ddp.post("data")
     assert ret == {}
-
-
-# Keys are "(uri, repr(data))", see conftest.py .
-test_dcrdatapath.HTTP_POST_RESP = {
-    ("", "''"): {},
-}


### PR DESCRIPTION
Add a test for `decred.dcr.dcrdata.DcrdataPath`.

In order to avoid accessing the network, a `conftest.py` file contains two pytest fixtures that monkeypatch the `get` and `post` functions in `decred.util.tinyhttp`.

The test file is called `test_dcrdata_unit.py` because pytest wants test filenames to be globally unique, unfortunately (and undocumentedly).

Part of #70.