### PR TITLE
Refactor errors

### DIFF
--- a/decred/decred/__init__.py
+++ b/decred/decred/__init__.py
@@ -1,0 +1,8 @@
+"""
+Copyright (c) 2019, the Decred developers
+See LICENSE for details
+"""
+
+
+class DecredError(Exception):
+    pass

--- a/decred/decred/config.py
+++ b/decred/decred/config.py
@@ -11,6 +11,7 @@ import os
 
 from appdirs import AppDirs
 
+from decred import DecredError
 from decred.dcr import nets
 from decred.util import helpers
 
@@ -57,7 +58,7 @@ def tinyNetConfig(netName):
         return TestnetConfig
     if netName == SIMNET:
         return SimnetConfig
-    raise Exception("unknown network")
+    raise DecredError("unknown network")
 
 
 class TinyConfig:

--- a/decred/decred/crypto/mnemonic.py
+++ b/decred/decred/crypto/mnemonic.py
@@ -6,6 +6,7 @@ See LICENSE for details
 PGP-based mnemonic seed generation.
 """
 
+from decred import DecredError
 from decred.util.encode import ByteArray
 
 from .crypto import sha256ChecksumByte
@@ -574,12 +575,11 @@ def decode(words):
         if word == "":
             continue
         if word not in byteMap:
-            raise Exception("unknown words in mnemonic key: %s" % word)
+            raise DecredError("unknown words in mnemonic key: %s" % word)
         b = byteMap[word]
         if int(b % 2) != idx % 2:
-            raise Exception(
-                "word %v is not valid at position %v, check for missing words"
-                % (word, idx)
+            raise DecredError(
+                f"word {word} is not valid at position {idx}, check for missing words"
             )
         decoded[idx] = b // 2
         idx += 1

--- a/decred/decred/crypto/secp256k1/curve.py
+++ b/decred/decred/crypto/secp256k1/curve.py
@@ -8,6 +8,7 @@ module curve
     dcrd golang version.
 """
 
+from decred import DecredError
 from decred.crypto.rando import generateSeed
 from decred.util.encode import ByteArray
 
@@ -344,7 +345,7 @@ class KoblitzCurve:
         format.
         """
         if len(pubKeyStr) == 0:
-            raise ValueError("empty pubkey string")
+            raise DecredError("empty pubkey string")
 
         fmt = pubKeyStr[0]
         ybit = (fmt & 0x1) == 0x1
@@ -355,7 +356,7 @@ class KoblitzCurve:
         pkLen = len(pubKeyStr)
         if pkLen == PUBKEY_LEN:
             if PUBKEY_UNCOMPRESSED != fmt:
-                raise ValueError("invalid magic in pubkey str: %d" % pubKeyStr[0])
+                raise DecredError("invalid magic in pubkey str: %d" % pubKeyStr[0])
             x = ifunc(pubKeyStr[1:33])
             y = ifunc(pubKeyStr[33:])
 
@@ -364,20 +365,20 @@ class KoblitzCurve:
             # solution determines which solution of the curve we use.
             # / y^2 = x^3 + Curve.B
             if PUBKEY_COMPRESSED != fmt:
-                raise ValueError(
+                raise DecredError(
                     "invalid magic in compressed pubkey string: %d" % pubKeyStr[0]
                 )
             x = ifunc(pubKeyStr[1:33])
             y = self.decompressPoint(x, ybit)
         else:  # wrong!
-            raise ValueError("invalid pub key length %d" % len(pubKeyStr))
+            raise DecredError("invalid pub key length %d" % len(pubKeyStr))
 
         if x > self.P:
-            raise ValueError("pubkey X parameter is >= to P")
+            raise DecredError("pubkey X parameter is >= to P")
         if y > self.P:
-            raise ValueError("pubkey Y parameter is >= to P")
+            raise DecredError("pubkey Y parameter is >= to P")
         if not self.isAffineOnCurve(x, y):
-            raise ValueError("pubkey [%d, %d] isn't on secp256k1 curve" % (x, y))
+            raise DecredError("pubkey [%d, %d] isn't on secp256k1 curve" % (x, y))
         return PublicKey(self, x, y)
 
     def decompressPoint(self, x, ybit):
@@ -399,7 +400,7 @@ class KoblitzCurve:
         if ybit == isEven(y):
             y = self.P - y
         if ybit == isEven(y):
-            raise Exception("ybit doesn't match oddnes")
+            raise DecredError("ybit doesn't match oddnes")
         return y
 
     def addJacobian(self, x1, y1, z1, x2, y2, z2, x3, y3, z3):  # *fieldVal) {

--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -3,6 +3,7 @@ Copyright (c) 2019, Brian Stafford
 See LICENSE for details
 """
 
+from decred import DecredError
 from decred.crypto import crypto, opcode
 from decred.util import encode, helpers
 
@@ -783,7 +784,7 @@ class Account(object):
             except crypto.CrazyKeyError:
                 continue
         # It is realistically impossible to reach here.
-        raise Exception("error finding voting key")
+        raise DecredError("error finding voting key")
 
     def close(self):
         """
@@ -1000,7 +1001,7 @@ class Account(object):
             addr = nextAddr()
             if addr != CrazyAddress:
                 return addr
-        raise Exception("failed to generate new address")
+        raise DecredError("failed to generate new address")
 
     def nextExternalAddress(self):
         """
@@ -1188,7 +1189,7 @@ class Account(object):
         """
         branch, idx = self.branchAndIndex(addr)
         if branch is None:
-            raise Exception("unknown address")
+            raise DecredError("unknown address")
 
         branchKey = self.privKey.child(branch)
         privKey = branchKey.child(idx)
@@ -1407,7 +1408,7 @@ class Account(object):
                 _, addresses, _ = txscript.extractPkScriptAddrs(
                     0, txout.pkScript, self.net
                 )
-            except Exception:
+            except DecredError:
                 # log.debug("unsupported script %s" % txout.pkScript.hex())
                 continue
             # convert the Address objects to strings.
@@ -1508,7 +1509,7 @@ class Account(object):
                 None,
             )
             if not redeemScript:
-                raise Exception("did not find redeem script for hash %s" % redeemHash)
+                raise DecredError("did not find redeem script for hash %s" % redeemHash)
 
             keysource = KeySource(
                 # This will need to change when we start using different
@@ -1533,7 +1534,7 @@ class Account(object):
         if stakePool:
             try:
                 stakePool.getPurchaseInfo()
-            except Exception as e:
+            except DecredError as e:
                 log.error("error getting VSP purchase info: %s" % e)
 
         # First, look at addresses that have been generated but not seen. Run in

--- a/decred/decred/dcr/calc.py
+++ b/decred/decred/dcr/calc.py
@@ -8,6 +8,7 @@ Some network math.
 import bisect
 import math
 
+from decred import DecredError
 from decred.util import helpers
 
 from . import constants as C
@@ -334,7 +335,7 @@ def attackCost(
     :param float rentalRate: The rental rate, in fiat/hash.
     """
     if any([x is None for x in (ticketFraction, xcRate, blockHeight)]):
-        raise Exception(
+        raise DecredError(
             "ticketFraction, xcRate, and blockHeight are required args/kwargs"
             " for AttackCost"
         )
@@ -343,7 +344,7 @@ def attackCost(
     poolSize = poolSize if poolSize else NETWORK.TicketExpiry
     treasurySplit = treasurySplit if treasurySplit else NETWORK.TREASURY_SPLIT
     if treasurySplit is None:
-        raise Exception("AttackCost: treasurySplit cannot be None")
+        raise DecredError("AttackCost: treasurySplit cannot be None")
 
     if stakeSplit:
         if not powSplit:
@@ -358,20 +359,20 @@ def attackCost(
     device = device if device else MODEL_DEVICE
     if nethash is None:
         if roi is None:  # mining ROI could be zero
-            raise Exception("minimizeY: Either a nethash or an roi must be provided")
+            raise DecredError("minimizeY: Either a nethash or an roi must be provided")
         nethash = ReverseEquations.networkHashrate(
             device, xcRate, roi, blockHeight, blockTime, powSplit
         )
     if rentability or rentalRatio:
         if not rentalRate:
-            raise Exception(
+            raise DecredError(
                 "minimizeY: If rentability is non-zero, rentalRate must be provided"
             )
     else:
         rentalRate = 0
     if ticketPrice is None:
         if not apy:
-            raise Exception(
+            raise DecredError(
                 "minimizeY: Either a ticketPrice or an apy must be provided"
             )
         ticketPrice = ReverseEquations.ticketPrice(
@@ -417,7 +418,7 @@ def purePowAttackCost(
     **kwargs
 ):
     if any([x is None for x in (xcRate, blockHeight)]):
-        raise Exception(
+        raise DecredError(
             "xcRate and blockHeight are required args/kwargs for PurePowAttackCost"
         )
     blockTime = blockTime if blockTime else NETWORK.TargetTimePerBlock
@@ -425,13 +426,13 @@ def purePowAttackCost(
     treasurySplit = treasurySplit if treasurySplit else NETWORK.TREASURY_SPLIT
     if nethash is None:
         if roi is None:  # mining ROI could be zero
-            raise Exception("minimizeY: Either a nethash or an roi must be provided")
+            raise DecredError("minimizeY: Either a nethash or an roi must be provided")
         nethash = ReverseEquations.networkHashrate(
             device, xcRate, roi, blockHeight, blockTime, 1 - treasurySplit
         )
     if rentability or rentalRatio:
         if not rentalRate:
-            raise Exception(
+            raise DecredError(
                 "minimizeY: If rentability is non-zero, rentalRate must be provided"
             )
     else:

--- a/decred/decred/dcr/nets/__init__.py
+++ b/decred/decred/dcr/nets/__init__.py
@@ -3,6 +3,8 @@ Copyright (c) 2019, The Decred developers
 See LICENSE for details
 """
 
+from decred import DecredError
+
 from . import mainnet, simnet, testnet
 
 
@@ -18,4 +20,4 @@ def parse(name):
     try:
         return the_nets[name]
     except KeyError:
-        raise ValueError(f"unrecognized network name {name}")
+        raise DecredError(f"unrecognized network name {name}")

--- a/decred/decred/dcr/wire/msgtx.py
+++ b/decred/decred/dcr/wire/msgtx.py
@@ -6,6 +6,7 @@ See LICENSE for details
 Based on dcrd MsgTx.
 """
 
+from decred import DecredError
 from decred.crypto.crypto import hashH
 from decred.util.encode import ByteArray
 
@@ -73,7 +74,7 @@ def readOutPoint(b, pver, ver):
 
 def readTxInPrefix(b, pver, serType, ver, ti):
     if serType == wire.TxSerializeOnlyWitness:
-        raise ValueError(
+        raise DecredError(
             "readTxInPrefix: tried to read a prefix input for a witness only tx"
         )
 
@@ -130,7 +131,7 @@ def readScript(b, pver, maxAllowed, fieldName):
     # upper bound on this count.
     if count > maxAllowed:
         msg = "readScript: {} is larger than the max allowed size [count {}, max {}]"
-        raise ValueError(msg.format(fieldName, count, maxAllowed))
+        raise DecredError(msg.format(fieldName, count, maxAllowed))
 
     a = b.pop(count)
 
@@ -672,7 +673,7 @@ class MsgTx:
         # message.  It would be possible to cause memory exhaustion and panics
         # without a sane upper bound on this count.
         if count > maxTxInPerMessage:
-            raise Exception(
+            raise DecredError(
                 "MsgTx.decodePrefix: too many input transactions to fit into"
                 " max message size [count %d, max %d]" % (count, maxTxInPerMessage)
             )
@@ -688,7 +689,7 @@ class MsgTx:
         # message.  It would be possible to cause memory exhaustion and panics
         # without a sane upper bound on this count.
         if count > maxTxOutPerMessage:
-            raise Exception(
+            raise DecredError(
                 "MsgTx.decodePrefix: too many output transactions to fit into"
                 " max message size [count %d, max %d]" % (count, maxTxOutPerMessage)
             )
@@ -718,7 +719,7 @@ class MsgTx:
         # Prevent more input transactions than could possibly fit into a
         # message, or memory exhaustion and panics could happen.
         if count > maxTxInPerMessage:
-            raise ValueError(
+            raise DecredError(
                 "MsgTx.decodeWitness: too many input transactions to fit into"
                 f" max message size [count {count}, max {maxTxInPerMessage}]"
             )
@@ -727,7 +728,7 @@ class MsgTx:
             # the number of signature scripts is the same as the number of
             # TxIns we currently have, then fill in the signature scripts.
             if count != len(self.txIn):
-                raise ValueError(
+                raise DecredError(
                     "MsgTx.decodeWitness: non equal witness and prefix txin"
                     f" quantities (witness {count}, prefix {len(self.txIn)})"
                 )

--- a/decred/decred/dcr/wire/wire.py
+++ b/decred/decred/dcr/wire/wire.py
@@ -6,6 +6,7 @@ See LICENSE for details
 Constants and common routines from the dcrd wire package.
 """
 
+from decred import DecredError
 from decred.util.encode import ByteArray
 
 
@@ -158,7 +159,7 @@ def readVarInt(b, pver):  # r io.Reader, pver uint32) (uint64, error) {
         # encoded using fewer bytes.
         minRv = 0x100000000
         if rv < minRv:
-            raise ValueError(err_msg.format(rv, discriminant, minRv))
+            raise DecredError(err_msg.format(rv, discriminant, minRv))
 
     elif discriminant == 0xFE:
         rv = b.pop(4).unLittle().int()
@@ -167,7 +168,7 @@ def readVarInt(b, pver):  # r io.Reader, pver uint32) (uint64, error) {
         # encoded using fewer bytes.
         minRv = 0x10000
         if rv < minRv:
-            raise ValueError(err_msg.format(rv, discriminant, minRv))
+            raise DecredError(err_msg.format(rv, discriminant, minRv))
 
     elif discriminant == 0xFD:
         rv = b.pop(2).unLittle().int()
@@ -176,7 +177,7 @@ def readVarInt(b, pver):  # r io.Reader, pver uint32) (uint64, error) {
         # encoded using fewer bytes.
         minRv = 0xFD
         if rv < minRv:
-            raise ValueError(err_msg.format(rv, discriminant, minRv))
+            raise DecredError(err_msg.format(rv, discriminant, minRv))
 
     else:
         rv = discriminant

--- a/decred/decred/util/database.py
+++ b/decred/decred/util/database.py
@@ -16,12 +16,14 @@ Blobber API:
 import sqlite3
 import threading
 
+from decred import DecredError
 
-class NoValue(Exception):
+
+class NoValueError(DecredError):
     pass
 
 
-NO_VALUE_EXCEPTION = NoValue("no value")
+NO_VALUE_EXCEPTION = NoValueError("no value")
 
 KVTable = "CREATE TABLE IF NOT EXISTS {tablename} (k {keytype}, v {valuetype});"
 
@@ -80,7 +82,7 @@ class KeyValueDatabase:
             Bucket: The root bucket.
         """
         if "$" in name:
-            raise ValueError("illegal character. '$' not allowed in table name")
+            raise DecredError("illegal character. '$' not allowed in table name")
         return Bucket(self.conn, name, **k)
 
     def close(self):
@@ -176,7 +178,7 @@ class Bucket:
                 constructor.
         """
         if "$" in name:
-            raise ValueError("illegal character. '$' not allowed in table name")
+            raise DecredError("illegal character. '$' not allowed in table name")
         compoundName = "{parent}${child}".format(parent=self.name, child=name)
         return Bucket(self.conn, compoundName, **k)
 

--- a/decred/decred/util/encode.py
+++ b/decred/decred/util/encode.py
@@ -8,6 +8,8 @@ A class that wraps ByteArray and provides some convenient operators.
 
 import struct
 
+from decred import DecredError
+
 
 NONE = "None".encode()
 
@@ -204,7 +206,7 @@ class ByteArray(object):
         a = decodeBA(a)
         aLen, bLen = len(a), len(self.b)
         if aLen > bLen:
-            raise ValueError("decode: invalid length %i > %i" % (aLen, bLen))
+            raise DecredError("decode: invalid length %i > %i" % (aLen, bLen))
         return a, aLen, self.b, bLen
 
     def __lt__(self, a):
@@ -405,11 +407,11 @@ def extractPushes(b):
         b = b[1:]
         if bLen == 255:
             if len(b) < 2:
-                raise Exception("2 bytes not available for uint16 data length")
+                raise DecredError("2 bytes not available for uint16 data length")
             bLen = intFromBytes(b[:2])
             b = b[2:]
         if len(b) < bLen:
-            raise Exception("data too short for pop of %d bytes" % bLen)
+            raise DecredError("data too short for pop of %d bytes" % bLen)
         pushes.append(b[:bLen])
         b = b[bLen:]
     return pushes
@@ -428,7 +430,7 @@ def decodeBlob(b):
         list(bytes-like): The data pushes.
     """
     if len(b) == 0:
-        raise Exception("zero length blob not allowed")
+        raise DecredError("zero length blob not allowed")
     return b[0], extractPushes(b[1:])
 
 

--- a/decred/decred/wallet/api.py
+++ b/decred/decred/wallet/api.py
@@ -7,8 +7,10 @@ This module defines an API used by the wallet and implemented by each asset and
 node type.
 """
 
+from decred import DecredError
 
-class InsufficientFundsError(Exception):
+
+class InsufficientFundsError(DecredError):
     """
     Available account balance too low for requested funds.
     """

--- a/decred/tests/benchmark/util/test_database_benchmark.py
+++ b/decred/tests/benchmark/util/test_database_benchmark.py
@@ -45,5 +45,5 @@ def test_benchmark():
         assert len(db) == num
         lap("batch insert")
 
-        with pytest.raises(database.NoValue):
+        with pytest.raises(database.NoValueError):
             db["nonsense"]

--- a/decred/tests/integration/dcr/test_rpc.py
+++ b/decred/tests/integration/dcr/test_rpc.py
@@ -5,9 +5,10 @@ See LICENSE for details
 
 import os
 
-from base58 import b58decode, b58encode
+from base58 import b58decode
 import pytest
 
+from decred import DecredError
 from decred.crypto import crypto, opcode
 from decred.dcr import account, rpc, txscript
 from decred.dcr.nets import mainnet
@@ -153,7 +154,7 @@ def test_rpc(config):
             break
 
     else:
-        raise Exception("did not find a suitable script to decode")
+        raise DecredError("did not find a suitable script to decode")
 
     existsExpiredTickets = rpcClient.existsExpiredTickets([aTicket, aTicket])
     assert existsExpiredTickets == [False, False]

--- a/decred/tests/unit/crypto/secp256k1/test_curve.py
+++ b/decred/tests/unit/crypto/secp256k1/test_curve.py
@@ -7,6 +7,7 @@ import random
 
 import pytest
 
+from decred import DecredError
 from decred.crypto.secp256k1 import curve
 from decred.crypto.secp256k1.curve import curve as curve_obj
 from decred.util.encode import ByteArray
@@ -781,7 +782,7 @@ def test_public_keys():
         if test["isValid"]:
             pk = curve_obj.parsePubKey(test["key"])
         else:
-            with pytest.raises(ValueError):
+            with pytest.raises(DecredError):
                 curve_obj.parsePubKey(test["key"])
             # Invalid key has no serialization format.
             continue

--- a/decred/tests/unit/crypto/test_crypto.py
+++ b/decred/tests/unit/crypto/test_crypto.py
@@ -5,6 +5,7 @@ See LICENSE for details
 
 import unittest
 
+from decred import DecredError
 from decred.crypto import crypto, rando
 from decred.dcr.nets import mainnet
 from decred.util.encode import ByteArray
@@ -185,7 +186,7 @@ class TestCrypto(unittest.TestCase):
         # fmt: off
         # Incorrect length of network version bytes.
         self.assertRaises(
-            ValueError,
+            DecredError,
             crypto.ExtendedKey,
             # privVer too short.
             ByteArray([0, 0, 0]),
@@ -193,7 +194,7 @@ class TestCrypto(unittest.TestCase):
             None, None, None, None, None, None, None
         )
         self.assertRaises(
-            ValueError,
+            DecredError,
             crypto.ExtendedKey,
             ByteArray([0, 0, 0, 0]),
             # pubVer too long.
@@ -205,4 +206,4 @@ class TestCrypto(unittest.TestCase):
         # Cannot serialize an empty private key.
         kpriv2 = crypto.ExtendedKey.new(testSeed)
         kpriv2.key.zero()
-        self.assertRaises(ValueError, kpriv2.serialize)
+        self.assertRaises(DecredError, kpriv2.serialize)

--- a/decred/tests/unit/crypto/test_mnemonic.py
+++ b/decred/tests/unit/crypto/test_mnemonic.py
@@ -5,6 +5,7 @@ See LICENSE for details
 
 import unittest
 
+from decred import DecredError
 from decred.crypto import mnemonic
 from decred.util.encode import ByteArray
 
@@ -47,4 +48,4 @@ class TestMnemonic(unittest.TestCase):
     def test_bad_paths(self):
         wordlists = (["", "meme"], ["acme", "kiwi"])
         for wordlist in wordlists:
-            self.assertRaises(Exception, mnemonic.decode, wordlist)
+            self.assertRaises(DecredError, mnemonic.decode, wordlist)

--- a/decred/tests/unit/dcr/conftest.py
+++ b/decred/tests/unit/dcr/conftest.py
@@ -1,0 +1,40 @@
+"""
+Copyright (c) 2019, the Decred developers
+See LICENSE for details
+"""
+
+import pytest
+
+from decred.util import tinyhttp
+
+
+@pytest.fixture
+def http_get(request, monkeypatch):
+    """
+    Use this fixture in tests while defining the responses to be returned in
+    a "HTTP_GET_RESP" function-level dict with "uri" as keys.
+    """
+    get_resp = getattr(request.function, "HTTP_GET_RESP")
+
+    def mock_get(uri, **kwargs):
+        nonlocal get_resp
+        return get_resp[uri]
+
+    # Avoid calling the actual tinyhttp.get .
+    monkeypatch.setattr(tinyhttp, "get", mock_get)
+
+
+@pytest.fixture
+def http_post(request, monkeypatch):
+    """
+    Use this fixture in tests while defining the responses to be returned in
+    a "HTTP_POST_RESP" function-level dict with "(uri, repr(data))" as keys.
+    """
+    post_resp = getattr(request.function, "HTTP_POST_RESP")
+
+    def mock_post(uri, data, **kwargs):
+        nonlocal post_resp
+        return post_resp[(uri, repr(data))]
+
+    # Avoid calling the actual tinyhttp.post .
+    monkeypatch.setattr(tinyhttp, "post", mock_post)

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -1,0 +1,40 @@
+"""
+Copyright (c) 2019, the Decred developers
+See LICENSE for details
+"""
+
+import pytest
+
+from decred.dcr import dcrdata
+
+
+def test_dcrdatapath(http_post):
+    ddp = dcrdata.DcrdataPath()
+
+    # __getattr__
+    with pytest.raises(dcrdata.DcrDataException):
+        ddp.no_such_path()
+
+    # Empty URI, needed for post.
+    with pytest.raises(dcrdata.DcrDataException):
+        ddp.getCallsignPath()
+    ddp.addCallsign([], "")
+    csp = ddp.getCallsignPath()
+    assert csp == ""
+
+    # Non-empty URI.
+    with pytest.raises(dcrdata.DcrDataException):
+        ddp.getCallsignPath("address")
+    ddp.addCallsign(["address"], "/%s")
+    csp = ddp.getCallsignPath("address", address="1234")
+    assert csp == "/address?address=1234"
+
+    # Post.
+    ret = ddp.post("")
+    assert ret == {}
+
+
+# Keys are "(uri, repr(data))", see conftest.py .
+test_dcrdatapath.HTTP_POST_RESP = {
+    ("", "''"): {},
+}

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -12,18 +12,18 @@ def test_dcrdatapath(http_post):
     ddp = dcrdata.DcrdataPath()
 
     # __getattr__
-    with pytest.raises(dcrdata.DcrDataException):
+    with pytest.raises(dcrdata.DcrDataError):
         ddp.no_such_path()
 
     # Empty URI, needed for post.
-    with pytest.raises(dcrdata.DcrDataException):
+    with pytest.raises(dcrdata.DcrDataError):
         ddp.getCallsignPath()
     ddp.addCallsign([], "")
     csp = ddp.getCallsignPath()
     assert csp == ""
 
     # Non-empty URI.
-    with pytest.raises(dcrdata.DcrDataException):
+    with pytest.raises(dcrdata.DcrDataError):
         ddp.getCallsignPath("address")
     ddp.addCallsign(["address"], "/%s")
     csp = ddp.getCallsignPath("address", address="1234")

--- a/decred/tests/unit/dcr/test_nets.py
+++ b/decred/tests/unit/dcr/test_nets.py
@@ -5,11 +5,12 @@ See LICENSE for details
 
 import pytest
 
+from decred import DecredError
 from decred.dcr import nets
 
 
 def test_nets():
     assert nets.parse("mainnet") is nets.mainnet
 
-    with pytest.raises(ValueError):
+    with pytest.raises(DecredError):
         nets.parse("nonet")

--- a/decred/tests/unit/dcr/wire/test_msgtx.py
+++ b/decred/tests/unit/dcr/wire/test_msgtx.py
@@ -6,6 +6,7 @@ See LICENSE for details
 import time
 import unittest
 
+from decred import DecredError
 from decred.crypto import rando
 from decred.dcr.wire import msgtx, wire
 from decred.util import helpers
@@ -366,7 +367,7 @@ class TestMsgTx(unittest.TestCase):
 
         for i, (buf, pver, version) in enumerate(tests):
             # Decode from wire format.
-            with self.assertRaises(Exception, msg="test %i" % i):
+            with self.assertRaises(DecredError, msg="test %i" % i):
                 msgtx.MsgTx.btcDecode(buf, pver)
 
     def test_tx_serialize_errors(self):
@@ -526,7 +527,7 @@ class TestMsgTx(unittest.TestCase):
 
     def test_read_tx_in_prefix(self):
         self.assertRaises(
-            ValueError,
+            DecredError,
             msgtx.readTxInPrefix,
             None,
             None,
@@ -537,7 +538,7 @@ class TestMsgTx(unittest.TestCase):
 
     def test_read_script(self):
         self.assertRaises(
-            ValueError,
+            DecredError,
             msgtx.readScript,
             ByteArray([0xFC]),
             wire.ProtocolVersion,

--- a/decred/tests/unit/dcr/wire/test_wire.py
+++ b/decred/tests/unit/dcr/wire/test_wire.py
@@ -5,6 +5,7 @@ See LICENSE for details
 
 import unittest
 
+from decred import DecredError
 from decred.dcr.wire import wire
 from decred.util import helpers
 from decred.util.encode import ByteArray
@@ -34,19 +35,19 @@ class TestWire(unittest.TestCase):
             val_from_bytes = wire.readVarInt(from_bytes, wire.ProtocolVersion)
             self.assertEqual(val_from_bytes, val)
         self.assertRaises(
-            ValueError, wire.writeVarInt, wire.ProtocolVersion, wire.MaxUint64 + 1
+            DecredError, wire.writeVarInt, wire.ProtocolVersion, wire.MaxUint64 + 1
         )
 
     def test_read_var_int(self):
         self.assertEqual(wire.readVarInt(ByteArray([0xFC]), wire.ProtocolVersion), 0xFC)
         self.assertRaises(
-            ValueError,
+            DecredError,
             wire.readVarInt,
             ByteArray([0xFE, 0xFF, 0xFF, 0x0, 0x0]),
             wire.ProtocolVersion,
         )
         self.assertRaises(
-            ValueError,
+            DecredError,
             wire.readVarInt,
             ByteArray([0xFD, 0xFC, 0x0]),
             wire.ProtocolVersion,

--- a/decred/tests/unit/util/test_database.py
+++ b/decred/tests/unit/util/test_database.py
@@ -9,6 +9,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
+from decred import DecredError
 from decred.util import database
 from decred.util.encode import ByteArray
 
@@ -40,14 +41,14 @@ def test_database(prepareLogger, randBytes):
         master = database.KeyValueDatabase(os.path.join(tempDir, "tmp.sqlite"))
 
         # '$' in bucket name is illegal.
-        with pytest.raises(ValueError):
+        with pytest.raises(DecredError):
             master.child("a$b")
 
         try:
             db = master.child("test")
 
             # Again, '$' in bucket name is illegal.
-            with pytest.raises(ValueError):
+            with pytest.raises(DecredError):
                 db.child("c$d")
 
             # Create some test data.
@@ -128,7 +129,7 @@ def runPairs(db, testPairs):
     assert len(db) == len(testPairs) - 1
 
     # Make sure the right row was deleted.
-    with pytest.raises(database.NoValue):
+    with pytest.raises(database.NoValueError):
         v = db[k]
 
     # Remmove the corresponding test pair from the dict.


### PR DESCRIPTION
Refactor error handling in the whole library:

- create a top-level `DecredError(Exception)`;
- make all locally-defined exceptions derive from it;
- raise it in place of both `Exception` and `ValueError`;
- rename `crypto.KeyLengthException` to `KeyLengthError`;
- rename `util.database.NoValue` to `NoValueError`;
- move `dcrdata.DcrDataException` to the top of the `dcrdata.py` file;
- rename `dcrdata.DcrDataException` to `DcrDataError`;
- remove the `name` and `message` args from `DcrDataError`;
- adjust the exceptions expected from some tests.

Depends on #80.