### PR TITLE
Revert three traps from DecredError to Exception

### DIFF
--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -1534,7 +1534,7 @@ class Account(object):
         if stakePool:
             try:
                 stakePool.getPurchaseInfo()
-            except DecredError as e:
+            except Exception as e:
                 log.error("error getting VSP purchase info: %s" % e)
 
         # First, look at addresses that have been generated but not seen. Run in

--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -359,7 +359,7 @@ class Signature:
         if der:
             try:
                 canonicalPadding(rBytes)
-            except DecredError as e:
+            except Exception as e:
                 raise DecredError(
                     "malformed signature: bogus r padding or sign: {}".format(e)
                 )
@@ -382,7 +382,7 @@ class Signature:
         if der:
             try:
                 canonicalPadding(rBytes)
-            except DecredError as e:
+            except Exception as e:
                 raise DecredError(
                     "malformed signature: bogus s padding or sign: {}".format(e)
                 )


### PR DESCRIPTION
#81 improperly changed four traps from `Exception` to `DecredError`. One is reverted in #83, the remaining three are reverted here.