### PR TITLE
tests: add tests for makeOutputs and checkOutput in dcrdata.py

### DIFF
--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -508,12 +508,12 @@ def makeOutputs(pairs, chain):
         list(msgtx.TxOut): Transaction outputs.
     """
     outputs = []
-    for addrStr, amt in pairs:
-        if amt < 0:
-            raise DecredError("amt < 0")
-        # Make sure its atoms
+    for idx, (addrStr, amt) in enumerate(pairs):
+        # Make sure amt is atoms.
         if not isinstance(amt, int):
-            raise DecredError("amt is not integral")
+            raise DecredError(f"Decred amount #{idx} is not an integer")
+        if amt < 0:
+            raise DecredError(f"Decred amount #{idx} is negative")
         pkScript = txscript.makePayToAddrScript(addrStr, chain)
         outputs.append(msgtx.TxOut(value=amt, pkScript=pkScript))
     return outputs
@@ -522,15 +522,14 @@ def makeOutputs(pairs, chain):
 def checkOutput(output, fee):
     """
     checkOutput performs simple consensus and policy tests on a transaction
-    output.  Returns with errors.Invalid if output violates consensus rules, and
-    errors.Policy if the output violates a non-consensus policy.
+    output.
 
     Args:
         output (TxOut): The output to check
         fee (float): The transaction fee rate (/kB).
 
     Returns:
-        There is not return value. If an output is deemed invalid, an exception
+        There is no return value. If an output is deemed invalid, DecredError
         is raised.
     """
     if output.value < 0:

--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -2945,7 +2945,6 @@ def isUnspendable(amount, pkScript):
         or len(pkScript) > 0
         and pkScript[0] == opcode.OP_RETURN
     ):
-
         return True
 
     # The script is unspendable if it is guaranteed to fail at execution.

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -5,7 +5,11 @@ See LICENSE for details
 
 import pytest
 
-from decred.dcr import dcrdata
+from decred.crypto import opcode
+from decred.dcr import dcrdata, txscript
+from decred.dcr.nets import testnet
+from decred.dcr.wire import msgtx
+from decred.util.encode import ByteArray
 
 
 def test_dcrdatapath(http_get_post):
@@ -33,3 +37,42 @@ def test_dcrdatapath(http_get_post):
     http_get_post(("", "'data'"), {})
     ret = ddp.post("data")
     assert ret == {}
+
+
+def test_makeoutputs():
+    # Amount is non-integer.
+    with pytest.raises(dcrdata.DecredError):
+        dcrdata.makeOutputs([("", None)], None)
+
+    # Amount is negative.
+    with pytest.raises(dcrdata.DecredError):
+        dcrdata.makeOutputs([("", -1)], None)
+
+    address = "TsfDLrRkk9ciUuwfp2b8PawwnukYD7yAjGd"  # testnet return address
+    value = int(1 * 1e8)  # 1 DCR, atoms
+    output = dcrdata.makeOutputs([(address, value)], testnet)[0]
+    assert isinstance(output, msgtx.TxOut)
+    assert output.value == value
+
+
+def test_checkoutput():
+    # Amount is zero.
+    tx = msgtx.TxOut()
+    with pytest.raises(dcrdata.DecredError):
+        dcrdata.checkOutput(tx, 0)
+
+    # Amount is negative.
+    tx = msgtx.TxOut(-1)
+    with pytest.raises(dcrdata.DecredError):
+        dcrdata.checkOutput(tx, 0)
+
+    # Amount is too large.
+    tx = msgtx.TxOut(txscript.MaxAmount + 1)
+    with pytest.raises(dcrdata.DecredError):
+        dcrdata.checkOutput(tx, 0)
+
+    # Tx is dust output.
+    script = ByteArray([opcode.OP_RETURN, opcode.OP_NOP])
+    tx = msgtx.TxOut(value=1, pkScript=script)
+    with pytest.raises(dcrdata.DecredError):
+        dcrdata.checkOutput(tx, 0)


### PR DESCRIPTION
Add tests for `makeOutputs` and `checkOutput` in `dcrdata.py`. Part of #70.