### PR TITLE
Tests: initial unit tests for DcrdataBlockchain

### DIFF
--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -55,7 +55,7 @@ def filterCrazyAddress(addrs):
     return [a for a in addrs if a != CrazyAddress]
 
 
-class KeySource(object):
+class KeySource:
     """
     Implements the KeySource API from tinydecred.api. Must provide access to
     internal addresses via the KeySource.internal method, and PrivateKeys for a
@@ -138,7 +138,7 @@ class TicketStats:
         self.value = value
 
 
-class TinyBlock(object):
+class TinyBlock:
     """
     TinyBlock is a block hash and height that satisfies encode.Blobber.
     """
@@ -205,7 +205,7 @@ class TinyBlock(object):
         return self.hash == blk.hash and self.height == blk.height
 
 
-class TicketInfo(object):
+class TicketInfo:
     """
     Ticket-related transaction information.
     """
@@ -327,7 +327,7 @@ class TicketInfo(object):
         return ByteArray(TicketInfo.blob(self))
 
 
-class UTXO(object):
+class UTXO:
     """
     The UTXO is part of the wallet API. BlockChains create and parse UTXO
     objects and fill fields as required by the Wallet.
@@ -570,7 +570,7 @@ class UTXO(object):
         return self.tinfo and self.tinfo.status in ("expired", "missed")
 
 
-class Balance(object):
+class Balance:
     """
     Information about an account's balance.
     The `total` attribute will contain the sum of the value of all UTXOs known
@@ -626,7 +626,7 @@ class Balance(object):
         )
 
 
-class Account(object):
+class Account:
     """
     Account is a Decred account.
     """

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -40,15 +40,7 @@ POST_HEADERS = {
 }
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 class DcrdataError(DecredError):
-=======
-class DcrDataError(DecredError):
->>>>>>> Test DcrdataClient in dcrdata.py using a MockWebsocketClient.
-=======
-class DcrdataError(DecredError):
->>>>>>> Fix case: DcrDataError -> DcrdataError
     pass
 
 

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -894,9 +894,10 @@ class DcrdataBlockchain:
             utxosource func(int, func(UTXO) -> bool) -> (list(UTXO), bool):
                 A function that takes an amount in atoms, and an optional
                 filtering function. utxosource returns a list of UTXOs that sum
-                to >= the amount. If the filtering function is provided, UTXOs
-                for which the  function return a falsey value will not be
-                included in the returned UTXO list.
+                to >= the amount, and a bool that states whether the funds are
+                sufficient to complete the transaction. If the filtering
+                function is provided, UTXOs for which the  function return a
+                falsey value will not be included in the returned UTXO list.
 
         Returns:
             newTx MsgTx: The sent transaction.

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -40,7 +40,11 @@ POST_HEADERS = {
 }
 
 
+<<<<<<< HEAD
 class DcrdataError(DecredError):
+=======
+class DcrDataError(DecredError):
+>>>>>>> Test DcrdataClient in dcrdata.py using a MockWebsocketClient.
     pass
 
 

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -472,13 +472,13 @@ class DcrdataBlockchain:
     def __init__(self, db, params, datapath, skipConnect=False):
         """
         Args:
-            db (str||database.Bucket): The database bucket or a filepath. If
-                a filepath, a new database will be created.
-            params obj: Network parameters
-            datapath str: A uri for a dcrdata server
-            skipConnect bool: Skip initial connection
+            db (str | database.Bucket): The database bucket or a filepath.
+                If a filepath, a new database will be created.
+            params obj: blockchain network parameters.
+            datapath str: a URI for a dcrdata server.
+            skipConnect bool: skip initial connection to dcrdata.
         """
-        # Allow string arguments for datab
+        # Allow string arguments for database.
         self.ownsDB = False
         if isinstance(db, str):
             self.ownsDB = True
@@ -765,10 +765,9 @@ class DcrdataBlockchain:
         """
         try:
             self.tip = self.bestBlock()
-            return
         except Exception as e:
             log.error("failed to retrieve tip from blockchain: %s" % formatTraceback(e))
-        raise DecredError("no tip data retrieved")
+            raise DecredError("no tip data retrieved")
 
     def relayFee(self):
         """

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -41,10 +41,14 @@ POST_HEADERS = {
 
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 class DcrdataError(DecredError):
 =======
 class DcrDataError(DecredError):
 >>>>>>> Test DcrdataClient in dcrdata.py using a MockWebsocketClient.
+=======
+class DcrdataError(DecredError):
+>>>>>>> Fix case: DcrDataError -> DcrdataError
     pass
 
 

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -648,7 +648,7 @@ class DcrdataBlockchain:
                     "unable to retrieve tx data from dcrdata at %s: %s"
                     % (self.dcrdata.baseURI, e)
                 )
-        raise DecredError("failed to retreive transaction")
+        raise DecredError("failed to retrieve transaction")
 
     def blockForTx(self, txid):
         """
@@ -888,20 +888,20 @@ class DcrdataBlockchain:
           (dcrwallet/wallet/txauthor).AddAllInputScripts
 
         Args:
-            outputs (list(TxOut)): The transaction outputs to send.
+            outputs list(TxOut): The transaction outputs to send.
             keysource func(str) -> PrivateKey: A function that returns the
                 private key for an address.
-            utxosource func(int, func(UTXO) -> bool) -> list(UTXO): A function
-                that takes an amount in atoms, and an optional filtering
-                function. utxosource returns a list of UTXOs that sum to >= the
-                amount. If the filtering function is provided, UTXOs for which
-                the  function return a falsey value will not be included in the
-                returned UTXO list.
+            utxosource func(int, func(UTXO) -> bool) -> (list(UTXO), bool):
+                A function that takes an amount in atoms, and an optional
+                filtering function. utxosource returns a list of UTXOs that sum
+                to >= the amount. If the filtering function is provided, UTXOs
+                for which the  function return a falsey value will not be
+                included in the returned UTXO list.
 
         Returns:
-            MsgTx: The sent transaction.
-            list(UTXO): The spent UTXOs.
-            list(UTXO): Length 1 array containing the new change UTXO.
+            newTx MsgTx: The sent transaction.
+            utxos list(UTXO): The spent UTXOs.
+            newUTXOs list(UTXO): Length 1 array containing the new change UTXO.
         """
         total = 0
         inputs = []
@@ -1035,17 +1035,18 @@ class DcrdataBlockchain:
         available.
 
         Args:
-            keysource (account.KeySource): A source for private keys.
-            utxosource (func(int, filterFunc) -> list(UTXO)): A source for
+            keysource account.KeySource: A source for private keys.
+            utxosource func(int, filterFunc) -> (list(UTXO), bool): A source for
                 UTXOs. The filterFunc is an optional function to filter UTXOs,
                 and is of the form func(UTXO) -> bool.
-            req (account.TicketRequest): The ticket data.
+            req account.TicketRequest: The ticket data.
 
         Returns:
-            tuple: First element is the split transaction. Second is a list of
-                generated tickets.
-            list (msgtx.TxOut): The outputs spent for the split transaction.
-            internalOutputs (msgtx.TxOut): New outputs that fund internal
+            (splitTx, tickets) tuple: First element is the split transaction.
+                Second is a list of generated tickets.
+            splitSpent list(msgtx.TxOut): The outputs spent for the split
+                transaction.
+            internalOutputs list(msgtx.TxOut): New outputs that fund internal
                 addresses.
 
         """

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -464,7 +464,7 @@ class DcrdataBlockchain:
     def __init__(self, db, params, datapath, skipConnect=False):
         """
         Args:
-            db (str | database.Bucket): The database bucket or a filepath.
+            db (str | database.Bucket): the database bucket or a filepath.
                 If a filepath, a new database will be created.
             params obj: blockchain network parameters.
             datapath str: a URI for a dcrdata server.
@@ -1036,18 +1036,18 @@ class DcrdataBlockchain:
         available.
 
         Args:
-            keysource account.KeySource: A source for private keys.
-            utxosource func(int, filterFunc) -> (list(UTXO), bool): A source for
+            keysource account.KeySource: a source for private keys.
+            utxosource func(int, filterFunc) -> (list(UTXO), bool): a source for
                 UTXOs. The filterFunc is an optional function to filter UTXOs,
                 and is of the form func(UTXO) -> bool.
-            req account.TicketRequest: The ticket data.
+            req account.TicketRequest: the ticket data.
 
         Returns:
-            (splitTx, tickets) tuple: First element is the split transaction.
+            (splitTx, tickets) tuple: first element is the split transaction.
                 Second is a list of generated tickets.
-            splitSpent list(msgtx.TxOut): The outputs spent for the split
+            splitSpent list(msgtx.TxOut): the outputs spent for the split
                 transaction.
-            internalOutputs list(msgtx.TxOut): New outputs that fund internal
+            internalOutputs list(msgtx.TxOut): new outputs that fund internal
                 addresses.
 
         """

--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -2892,13 +2892,11 @@ def calcMinRequiredTxRelayFee(relayFeePerKb, txSerializeSize):
     return round(fee)
 
 
-def isDustAmount(
-    amount, scriptSize, relayFeePerKb
-):  # amount dcrutil.Amount, scriptSize int, relayFeePerKb dcrutil.Amount) bool {
+def isDustAmount(amount, scriptSize, relayFeePerKb):
     """
-    isDustAmount determines whether a transaction output value and script length would
-    cause the output to be considered dust.  Transactions with dust outputs are
-    not standard and are rejected by mempools with default policies.
+    isDustAmount determines whether a transaction output value and script length
+    would cause the output to be considered dust.  Transactions with dust outputs
+    are not standard and are rejected by mempools with default policies.
 
     Args:
         amount (int): Atoms.

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -91,6 +91,19 @@ def test_checkoutput():
         checkOutput(tx, 0)
 
 
+def make_dcrdataclient(http_get_post):
+    # Load the list of API calls.
+    data_file = Path(__file__).resolve().parent / "test-data" / "dcrdata.json"
+    with open(data_file) as f:
+        api_list = json.loads(f.read())
+
+    # Queue the list of API calls.
+    base_url = "https://example.org/"
+    http_get_post(f"{base_url}api/list", api_list)
+
+    return dcrdata.DcrdataClient(base_url)
+
+
 class MockWebsocketClient:
     def __init__(self):
         self.sent = []

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -88,6 +88,8 @@ def test_dcrdatapath(http_get_post):
     ret = ddp.post("data")
     assert ret == {}
 
+
+def test_makeoutputs():
     # Amount is non-integer.
     with pytest.raises(DecredError):
         makeOutputs([("", None)], None)

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -10,11 +10,9 @@ from pathlib import Path
 
 import pytest
 
-# Use after #82 is merged.
-# from decred.dcr import agenda
 from decred import DecredError
 from decred.crypto import opcode
-from decred.dcr import txscript
+from decred.dcr import agenda, txscript
 from decred.dcr.dcrdata import (
     DcrdataBlockchain,
     DcrdataClient,
@@ -23,7 +21,6 @@ from decred.dcr.dcrdata import (
     checkOutput,
     makeOutputs,
 )
-from decred.dcr.dcrdata import AgendasInfo  # Remove after #82 is merged.
 from decred.dcr.nets import testnet
 from decred.dcr.wire import msgtx
 from decred.util.encode import ByteArray
@@ -220,6 +217,4 @@ class TestDcrdataBlockchain:
         # getAgendasInfo.
         http_get_post(f"{base_url}api/stake/vote/info", AGENDAS_INFO_RAW)
         agsinfo = ddb.getAgendasInfo()
-        # Use after #82 is merged.
-        # assert isinstance(agsinfo, agenda.AgendasInfo)
-        assert isinstance(agsinfo, AgendasInfo)
+        assert isinstance(agsinfo, agenda.AgendasInfo)

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -51,7 +51,6 @@ def test_dcrdatapath(http_get_post):
     ret = ddp.post("data")
     assert ret == {}
 
-
     # Amount is non-integer.
     with pytest.raises(DecredError):
         makeOutputs([("", None)], None)

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -16,16 +16,14 @@ from decred.dcr import txscript
 # Use after #82 is merged.
 # from decred.dcr import agenda
 from decred.dcr.dcrdata import (
-    # Remove after #82 is merged.
-    AgendasInfo,
     DcrdataBlockchain,
     DcrdataClient,
     DcrdataError,
     DcrdataPath,
-    DecredError,
     checkOutput,
     makeOutputs,
 )
+from decred.dcr.dcrdata import AgendasInfo  # Remove after #82 is merged.
 from decred.dcr.nets import testnet
 from decred.dcr.wire import msgtx
 from decred.util.encode import ByteArray

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -91,19 +91,6 @@ def test_checkoutput():
         checkOutput(tx, 0)
 
 
-def make_dcrdataclient(http_get_post):
-    # Load the list of API calls.
-    data_file = Path(__file__).resolve().parent / "test-data" / "dcrdata.json"
-    with open(data_file) as f:
-        api_list = json.loads(f.read())
-
-    # Queue the list of API calls.
-    base_url = "https://example.org/"
-    http_get_post(f"{base_url}api/list", api_list)
-
-    return dcrdata.DcrdataClient(base_url)
-
-
 class MockWebsocketClient:
     def __init__(self):
         self.sent = []

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -10,11 +10,11 @@ from pathlib import Path
 
 import pytest
 
+# Use after #82 is merged.
+# from decred.dcr import agenda
 from decred import DecredError
 from decred.crypto import opcode
 from decred.dcr import txscript
-# Use after #82 is merged.
-# from decred.dcr import agenda
 from decred.dcr.dcrdata import (
     DcrdataBlockchain,
     DcrdataClient,

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -26,6 +26,9 @@ from decred.dcr.wire import msgtx
 from decred.util.encode import ByteArray
 
 
+BASE_URL = "https://example.org/"
+
+
 AGENDA_CHOICES_RAW = dict(
     id="choices_id",
     description="description",
@@ -135,23 +138,19 @@ class MockWebsocketClient:
 
 
 def preload_api_list(http_get_post):
-
     # Load the list of API calls.
     data_file = Path(__file__).resolve().parent / "test-data" / "dcrdata.json"
     with open(data_file) as f:
         api_list = json.loads(f.read())
 
     # Queue the list of API calls.
-    base_url = "https://example.org/"
-    http_get_post(f"{base_url}api/list", api_list)
-
-    return base_url
+    http_get_post(f"{BASE_URL}api/list", api_list)
 
 
 class TestDcrdataClient:
     def test_misc(self, http_get_post, capsys):
-        base_url = preload_api_list(http_get_post)
-        ddc = DcrdataClient(base_url)
+        preload_api_list(http_get_post)
+        ddc = DcrdataClient(BASE_URL)
 
         assert len(ddc.listEntries) == 84
         assert len(ddc.subscribedAddresses) == 0
@@ -163,8 +162,8 @@ class TestDcrdataClient:
         assert len(out.splitlines()) == 84
 
     def test_subscriptions(self, http_get_post):
-        base_url = preload_api_list(http_get_post)
-        ddc = DcrdataClient(base_url)
+        preload_api_list(http_get_post)
+        ddc = DcrdataClient(BASE_URL)
 
         # Set the mock WebsocketClient.
         ddc.ps = MockWebsocketClient()
@@ -186,14 +185,14 @@ class TestDcrdataBlockchain:
     def test_subscriptions(self, http_get_post, tmp_path):
 
         # Exception in updateTip.
-        base_url = preload_api_list(http_get_post)
+        preload_api_list(http_get_post)
         with pytest.raises(DecredError):
-            DcrdataBlockchain(str(tmp_path / "test.db"), testnet, base_url)
+            DcrdataBlockchain(str(tmp_path / "test.db"), testnet, BASE_URL)
 
         # Successful creation.
-        base_url = preload_api_list(http_get_post)
-        http_get_post(f"{base_url}api/block/best", 1)
-        ddb = DcrdataBlockchain(str(tmp_path / "test.db"), testnet, base_url)
+        preload_api_list(http_get_post)
+        http_get_post(f"{BASE_URL}api/block/best", 1)
+        ddb = DcrdataBlockchain(str(tmp_path / "test.db"), testnet, BASE_URL)
         assert ddb.tip == 1
 
         # Set the mock WebsocketClient.
@@ -215,6 +214,109 @@ class TestDcrdataBlockchain:
         assert ddb.dcrdata.ps.sent[0]["message"]["message"] == "address:new_one"
 
         # getAgendasInfo.
-        http_get_post(f"{base_url}api/stake/vote/info", AGENDAS_INFO_RAW)
+        http_get_post(f"{BASE_URL}api/stake/vote/info", AGENDAS_INFO_RAW)
         agsinfo = ddb.getAgendasInfo()
         assert isinstance(agsinfo, agenda.AgendasInfo)
+
+    # Test data from block #427282.
+    utxos = [
+        # Coinbase.
+        dict(
+            address="DsnxqhJX2tjyjbfb9y4yPdpJ744G9fLhbbF",
+            txid="ba0ce58eaa1b1402b8f33d84034014712add4d2955d1dd01adea2612e9dc6b8a",
+            vout=2,
+            ts=1582827409,
+            scriptPubKey="76a914f14f995d7b8c37c961bdb1baf431a18026f7e31088ac",
+            height=427338,
+            amount=7.5534513,
+            satoshis=755345130,
+            confirmations=3,
+        ),
+        # Ticket.
+        dict(
+            address="Dcuq3UdEQ3SHy3W6wfmbsSZctQjKSn8o8HV",
+            txid="40039b114c2a497ebd324d9d6c34a20b32caedfb036fbcb5523471adbafa32a1",
+            vout=0,
+            ts=1582825041,
+            scriptPubKey="baa914f5618dfc002becfe840da65f6a49457f41d4f21787",
+            height=427325,
+            amount=147.73014984,
+            satoshis=14773014984,
+            confirmations=5,
+        ),
+        # Standard.
+        dict(
+            address="DshiCywHki7LeKK4G97ifphLR5hiicAhiKE",
+            txid="fe332b35fa0a8a8aa2d247a35f45553935e0b96d33e1a8158a1a863307d5bdf3",
+            vout=1,
+            ts=1582817341,
+            scriptPubKey="76a914b7b28003b805aaba589092e28f30e436f0cd05df88ac",
+            height=427282,
+            amount=80.81940674,
+            satoshis=8081940674,
+            confirmations=3,
+        ),
+    ]
+    txs = {
+        "ba0ce58eaa1b1402b8f33d84034014712add4d2955d1dd01adea2612e9dc6b8a": (
+            "0100000001000000000000000000000000000000000000000000000000000000000000000"
+            "0ffffffff00ffffffff03e8997c0700000000000017a914f5916158e3e2c4551c1796708d"
+            "b8367207ed13bb87000000000000000000000e6a0c4a850600589b9dfdecb7e667eaa6052"
+            "d0000000000001976a914f14f995d7b8c37c961bdb1baf431a18026f7e31088ac00000000"
+            "00000000015a3568340000000000000000ffffffff0800002f646372642f"
+        ),
+        "40039b114c2a497ebd324d9d6c34a20b32caedfb036fbcb5523471adbafa32a1": (
+            "01000000024f23123ce6a665cc092d2947a56ff6a88dcde4c74f72adff76d976b188611df"
+            "b0000000000ffffffff4f23123ce6a665cc092d2947a56ff6a88dcde4c74f72adff76d976"
+            "b188611dfb0100000000ffffffff05c8518a7003000000000018baa914f5618dfc002becf"
+            "e840da65f6a49457f41d4f2178700000000000000000000206a1ebee010b0d6369633d6fb"
+            "12d67559440e2146c8dbf7330b00000000000058000000000000000000001abd76a914000"
+            "000000000000000000000000000000000000088ac00000000000000000000206a1e9ce9c4"
+            "6b4e99d014ff8fcbc76fa374258d6b2f2afd327f700300000000580000000000000000000"
+            "01abd76a914000000000000000000000000000000000000000088ac000000008085060002"
+            "f7330b00000000003c8506000a0000006a47304402205cc30a0c1e4d22e7ac3473b80f778"
+            "9d694f17e18a39defe156814418edeeb34302207ec4eb9ae7eba710608e49b363129147c8"
+            "4319f8cf065733522a2ac16a66fd260121021f2675b5f8403d9095c1874efde16719684d0"
+            "490cc8836cbe5dadc3be4650dbbfd327f70030000003c8506000a0000006b483045022100"
+            "dce25b12cf5fb6d97123f7ed128df45452296c5f6b80736d34c23f71600445dc022062917"
+            "c128406c371983eceaeb9fa47e417f1d6b84da1f7faa888a2cda6cee8ad0121021f2675b5"
+            "f8403d9095c1874efde16719684d0490cc8836cbe5dadc3be4650dbb"
+        ),
+        "fe332b35fa0a8a8aa2d247a35f45553935e0b96d33e1a8158a1a863307d5bdf3": (
+            "01000000022b7417082c038ad30555f69723516b0372b2afbe7d888e3a52995a759c9b26b"
+            "e0200000001ffffffff81f6d14d0cc35a385af056bd3c3dd95e951fc9007ba9aaa76c3f31"
+            "7e7c7b969d0100000000ffffffff026c5d8a700300000000001976a914ead3999b4c08c93"
+            "248e54a6dea44f3a3e4e58fb088acc2a0b8e10100000000001976a914b7b28003b805aaba"
+            "589092e28f30e436f0cd05df88ac0000000000000000020e7367e20200000011840600020"
+            "000006a47304402207fcf2f4522fc243348f0691df3c6ec0e01eb3f160d97ed1d0b2b2eb7"
+            "21bba3ac0220799deaf6aa5053089a1ffae35298e67156c455f18a2862e6cdb54ec81c32f"
+            "d1d01210399a38b70c02626ffb64451b1b5d8b95fd9f8cb02aaaf062cd8e5a023a5a2fa37"
+            "7e9bdb6f02000000ec840600040000006a47304402200d5b9d3eb925d6f028640d810f152"
+            "a19ea462bf15a71eba2b5a6080c8b02e161022022d492ce6fc296d9cbc61122838add71e9"
+            "a01bbb7c53659d0ee8f7927b26eef6012103c8656c7d5002fdead42f844a6ea370c34d581"
+            "0bed487af9827a27a820b31a880"
+        ),
+    }
+
+    def test_utxos(self, http_get_post, tmp_path):
+        preload_api_list(http_get_post)
+        http_get_post(f"{BASE_URL}api/block/best", 1)
+        ddb = DcrdataBlockchain(str(tmp_path / "test.db"), testnet, BASE_URL)
+
+        assert len(ddb.UTXOs([])) == 0
+
+        # Precompute the UTXO data.
+        addrs = [utxo["address"] for utxo in self.utxos]
+        addrStr = ",".join(addrs)
+        utxoURL = f"{BASE_URL}insight/api/addr/{addrStr}/utxo"
+
+        # Preload the UTXOs but not the txs.
+        http_get_post(utxoURL, self.utxos)
+        with pytest.raises(DecredError):
+            ddb.UTXOs(addrs)
+
+        # Preload both the UTXOs and the txs.
+        http_get_post(utxoURL, self.utxos)
+        for txid, tx in self.txs.items():
+            http_get_post(f"{BASE_URL}api/tx/hex/{txid}", tx)
+        assert len(ddb.UTXOs(addrs)) == 3

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -52,7 +52,6 @@ def test_dcrdatapath(http_get_post):
     assert ret == {}
 
 
-def test_makeoutputs():
     # Amount is non-integer.
     with pytest.raises(DecredError):
         makeOutputs([("", None)], None)


### PR DESCRIPTION
This adds initial unit tests for `DcrdataBlockchain` in `dcrdata.py`. A test for subscriptions and one for UTXOs are included.

It also includes some docstring refactoring and other cleanup.

Part of #70.