### PR TITLE
tests: more unit tests for UTXOs in DcrdataBlockchain

### DIFF
--- a/decred/decred/config.py
+++ b/decred/decred/config.py
@@ -103,7 +103,7 @@ class TinyConfig:
     def get(self, *keys):
         """
         Retrieve the setting at the provided key path. Multiple keys can be
-        provided, with each successive key being retreived from the previous
+        provided, with each successive key being retrieved from the previous
         key's value.
 
         Args:

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -551,7 +551,7 @@ class DcrdataBlockchain:
         Check for coinbase or stakebase, and assign a maturity as necessary.
 
         Args:
-            utxo UTXO: A new unspent transaction output from blockchain.
+            utxo account.UTXO: A new unspent transaction output from blockchain.
 
         Returns:
             bool: True if no errors are encountered.
@@ -607,7 +607,8 @@ class DcrdataBlockchain:
         Get a UTXO from the outpoint. The UTXO will not have the address set.
 
         Args:
-            txid (str): Hex-encode txid
+            txid str: hex-encoded txid.
+            vout int: the chosen tx output index.
         """
         tx = self.tx(txid)
         txout = tx.txOut[vout]
@@ -665,28 +666,13 @@ class DcrdataBlockchain:
         except database.NoValueError:
             # If the blockhash is not in the database, get it from dcrdata
             decodedTx = self.dcrdata.tx(txid)
-            if (
-                "block" not in decodedTx
-                or "blockhash" not in decodedTx["block"]
-                or decodedTx["block"]["blockhash"] == ""
-            ):
+            try:
+                hexHash = decodedTx["block"]["blockhash"]
+            except KeyError:
                 return None
-            hexHash = decodedTx["block"]["blockhash"]
             header = self.blockHeader(hexHash)
             self.txBlockMap[txHash] = header.cachedHash().bytes()
             return header
-
-    def decodedTx(self, txid):
-        """
-        decodedTx will produce a transaction as a Python dict.
-
-        Args:
-            txid (str): Hex-encoded transaction ID.
-
-        Returns:
-            dict: A Python dict with transaction information.
-        """
-        return self.dcrdata.tx(txid)
 
     def blockHeader(self, hexHash):
         """
@@ -713,7 +699,7 @@ class DcrdataBlockchain:
 
     def blockHeaderByHeight(self, height):
         """
-        Get the block header by height. The blcck header is retreived from the
+        Get the block header by height. The block header is retrieved from the
         blockchain if necessary, in which case it is stored.
 
         Args:

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -666,9 +666,11 @@ class DcrdataBlockchain:
         except database.NoValueError:
             # If the blockhash is not in the database, get it from dcrdata
             decodedTx = self.dcrdata.tx(txid)
+            # Make sure the block hash is there and is not empty.
             try:
                 hexHash = decodedTx["block"]["blockhash"]
-            except KeyError:
+                hexHash[0]
+            except (KeyError, IndexError):
                 return None
             header = self.blockHeader(hexHash)
             self.txBlockMap[txHash] = header.cachedHash().bytes()

--- a/decred/decred/wallet/accounts.py
+++ b/decred/decred/wallet/accounts.py
@@ -221,7 +221,7 @@ class AccountManager(object):
         Returns:
             Account: The open account.
         """
-        # Retreive and open the account.
+        # Retrieve and open the account.
         account = self.accounts[acct] if acct in self.accounts else self.account(acct)
         account.open(cryptoKey, chains.chain(self.coinType), self.signals)
         return account

--- a/decred/decred/wallet/api.py
+++ b/decred/decred/wallet/api.py
@@ -369,7 +369,7 @@ class KeySource:
 
     def priv(self, addr):
         """
-        Retreive the private key for a base-58 encoded address.
+        Retrieve the private key for a base-58 encoded address.
 
         Args:
             addr (str): An address.


### PR DESCRIPTION
This adds more UTXO unit tests in `DcrdataBlockchain`.

It also includes more cleanup like removal of the unused `DcrdataBlockchain.decodedTx` method (see line 667-668 of the diff) and `s/retreive/retrieve/` all over the codebase.

Part of #70.