### PR TITLE
wire: fix a blockheader deserialize bug

### DIFF
--- a/decred/decred/dcr/wire/msgblock.py
+++ b/decred/decred/dcr/wire/msgblock.py
@@ -1,16 +1,16 @@
 """
 Copyright (c) 2019, Brian Stafford
-Copyright (c) 2019, The Decred developers
+Copyright (c) 2019-2020, The Decred developers
 See LICENSE for details
 
 Based on dcrd MsgBlock.
 """
 
-from decred.crypto.crypto import hashH
+from decred.crypto import crypto
 from decred.util.encode import ByteArray
 
 
-# chainhash.HashSize in go
+# chainhash.HashSize in Go
 HASH_SIZE = 32
 
 MaxHeaderSize = 180
@@ -86,10 +86,14 @@ class BlockHeader:
     @staticmethod
     def btcDecode(b, pver):
         """
-        BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
-        This is part of the Message interface implementation.
-        See Deserialize for decoding block headers stored to disk, such as in a
-        database, as opposed to decoding block headers from the wire.
+        BtcDecode decodes b using the bitcoin protocol encoding into the
+        receiver. This is part of the Message interface implementation.
+        See Deserialize for decoding block headers stored to disk, such as
+        in a database, as opposed to decoding block headers from the wire.
+
+        Args:
+            b (ByteArray): the bytes to decode.
+            pver (int): the protocol version.
         """
         bh = BlockHeader()
 
@@ -135,6 +139,10 @@ class BlockHeader:
 
     @staticmethod
     def deserialize(b):
+        """
+        Args:
+            b (bytes): the bytes to deserialize.
+        """
         return BlockHeader.btcDecode(ByteArray(b), 0)
 
     # blob and unblob satisfy the Blobber API from  util.database
@@ -145,10 +153,19 @@ class BlockHeader:
 
     @staticmethod
     def unblob(b):
-        """Satisfies the encode.Blobber API"""
+        """
+        Satisfies the encode.Blobber API.
+
+        Args:
+            b (bytes): the bytes to unblob.
+        """
         return BlockHeader.deserialize(b)
 
     def btcEncode(self, pver):
+        """
+        Args:
+            pver (int): the protocol version.
+        """
         # byte sizes
         int64 = 8
         int32 = uint32 = 4
@@ -200,7 +217,7 @@ class BlockHeader:
         """
         hash computes the block identifier hash for the given block header.
         """
-        return hashH(self.serialize().bytes())
+        return crypto.hashH(self.serialize().bytes())
 
     def cachedHash(self):
         """

--- a/decred/decred/dcr/wire/msgblock.py
+++ b/decred/decred/dcr/wire/msgblock.py
@@ -135,7 +135,7 @@ class BlockHeader:
 
     @staticmethod
     def deserialize(b):
-        return BlockHeader.btcDecode(b, 0)
+        return BlockHeader.btcDecode(ByteArray(b), 0)
 
     # blob and unblob satisfy the Blobber API from  util.database
     @staticmethod

--- a/decred/tests/unit/dcr/wire/test_msgblock.py
+++ b/decred/tests/unit/dcr/wire/test_msgblock.py
@@ -57,7 +57,7 @@ class TestBlockHeader(unittest.TestCase):
         bh, encoded = self.make_block_header()
         b = bh.serialize()
         self.assertEqual(b, encoded)
-        reBH = msgblock.BlockHeader.unblob(b)
+        reBH = msgblock.BlockHeader.unblob(ByteArray.hex(b))
         self.assertEqual(bh.version, reBH.version)
         self.assertEqual(bh.prevBlock, reBH.prevBlock)
         self.assertEqual(bh.merkleRoot, reBH.merkleRoot)

--- a/decred/tests/unit/dcr/wire/test_msgblock.py
+++ b/decred/tests/unit/dcr/wire/test_msgblock.py
@@ -1,15 +1,13 @@
 """
-Copyright (c) 2019, the Decred developers
+Copyright (c) 2019-2020, the Decred developers
 See LICENSE for details
 """
-
-import unittest
 
 from decred.dcr.wire import msgblock
 from decred.util.encode import ByteArray
 
 
-class TestBlockHeader(unittest.TestCase):
+class TestBlockHeader:
     def make_block_header(self):
         bh = msgblock.BlockHeader()
         bh.version = 6
@@ -56,30 +54,30 @@ class TestBlockHeader(unittest.TestCase):
     def test_decode(self):
         bh, encoded = self.make_block_header()
         b = bh.serialize()
-        self.assertEqual(b, encoded)
+        assert b == encoded
         reBH = msgblock.BlockHeader.unblob(ByteArray.hex(b))
-        self.assertEqual(bh.version, reBH.version)
-        self.assertEqual(bh.prevBlock, reBH.prevBlock)
-        self.assertEqual(bh.merkleRoot, reBH.merkleRoot)
-        self.assertEqual(bh.stakeRoot, reBH.stakeRoot)
-        self.assertEqual(bh.voteBits, reBH.voteBits)
-        self.assertEqual(bh.finalState, reBH.finalState)
-        self.assertEqual(bh.voters, reBH.voters)
-        self.assertEqual(bh.freshStake, reBH.freshStake)
-        self.assertEqual(bh.revocations, reBH.revocations)
-        self.assertEqual(bh.poolSize, reBH.poolSize)
-        self.assertEqual(bh.bits, reBH.bits)
-        self.assertEqual(bh.sBits, reBH.sBits)
-        self.assertEqual(bh.height, reBH.height)
-        self.assertEqual(bh.size, reBH.size)
-        self.assertEqual(bh.timestamp, reBH.timestamp)
-        self.assertEqual(bh.nonce, reBH.nonce)
-        self.assertEqual(bh.extraData, reBH.extraData)
-        self.assertEqual(bh.stakeVersion, reBH.stakeVersion)
-        self.assertEqual(bh.id(), reBH.id())
+        assert bh.version == reBH.version
+        assert bh.prevBlock == reBH.prevBlock
+        assert bh.merkleRoot == reBH.merkleRoot
+        assert bh.stakeRoot == reBH.stakeRoot
+        assert bh.voteBits == reBH.voteBits
+        assert bh.finalState == reBH.finalState
+        assert bh.voters == reBH.voters
+        assert bh.freshStake == reBH.freshStake
+        assert bh.revocations == reBH.revocations
+        assert bh.poolSize == reBH.poolSize
+        assert bh.bits == reBH.bits
+        assert bh.sBits == reBH.sBits
+        assert bh.height == reBH.height
+        assert bh.size == reBH.size
+        assert bh.timestamp == reBH.timestamp
+        assert bh.nonce == reBH.nonce
+        assert bh.extraData == reBH.extraData
+        assert bh.stakeVersion == reBH.stakeVersion
+        assert bh.id() == reBH.id()
 
     def test_cached_hash(self):
         bh, _ = self.make_block_header()
-        self.assertIsNone(bh.cachedH)
+        assert bh.cachedH is None
         hash_ = bh.cachedHash()
-        self.assertEqual(hash_, bh.cachedHash())
+        assert hash_ == bh.cachedHash()


### PR DESCRIPTION
`DcrdataBlockchain` testing highlighted a bug in `dcr.wire.msgblock.BlockHeader.deserialize`. The change is shown in the first commit: https://github.com/decred/tinydecred/commit/f05d21ba9f8f42409f3bbba01ab8d9f6655e7ea8.

The `deserialize` method was only working correctly when passed a ByteArray, and failed with a raw `bytes` or `bytearray`.  The test did not catch that because it passed to `unblob` the result of `serialize`, which is a ByteArray. The test is changed to pass raw bytes to `unblob`.

(Actually I'm not sure if the fix should be applied to `deserialize` or to `unblob`: I could not locate the `encode.Blobber` API.)

The second commit improves the docstrings and converts the test to pytest format.