### PR TITLE
txscript: Complete extractPkScriptAddrs

### DIFF
--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -1820,13 +1820,7 @@ class Account:
                 matches += 1
         # scan the outputs for any new UTXOs
         for vout, txout in enumerate(tx.txOut):
-            try:
-                _, addresses, _ = txscript.extractPkScriptAddrs(
-                    0, txout.pkScript, self.net
-                )
-            except (DecredError, NotImplementedError):
-                # log.debug("unsupported script %s" % txout.pkScript.hex())
-                continue
+            _, addresses, _ = txscript.extractPkScriptAddrs(0, txout.pkScript, self.net)
             # convert the Address objects to strings.
             if addr in (a.string() for a in addresses):
                 utxo = self.blockchain.txVout(txid, vout)

--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -805,12 +805,12 @@ def getScriptClass(scriptVersion, script):
         return NonStandardTy
     elif isPubKeyScript(script):
         return PubKeyTy
-    # elif isPubKeyAltScript(script):
-    #     return PubkeyAltTy
+    elif isPubKeyAltScript(script):
+        return PubkeyAltTy
     elif isPubKeyHashScript(script):
         return PubKeyHashTy
-    # elif isPubKeyHashAltScript(script):
-    #     return PubkeyHashAltTy
+    elif isPubKeyHashAltScript(script):
+        return PubkeyHashAltTy
     elif isScriptHashScript(script):
         return ScriptHashTy
     elif isMultisigScript(scriptVersion, script):
@@ -826,6 +826,123 @@ def getScriptClass(scriptVersion, script):
     elif isStakeChangeScript(scriptVersion, script):
         return StakeSubChangeTy
     return NonStandardTy
+
+
+def isPubKeyAltScript(script):
+    """
+    isPubKeyAltScript returns whether or not the passed script is a standard
+    pay-to-alt-pubkey script.
+    """
+    pk, _ = extractPubKeyAltDetails(script)
+    return pk is not None
+
+
+def extractPubKeyAltDetails(script):
+    """
+    extractPubKeyAltDetails extracts the public key and signature type from the
+    passed script if it is a standard pay-to-alt-pubkey script.  It will return
+    None otherwise.
+
+    Args:
+        script (bytes-like): The script to extract from.
+
+    Returns:
+        (bytes-like): The pubkey or None.
+        (int): The signature type or None.
+    """
+    # A pay-to-alt-pubkey script is of the form:
+    #  PUBKEY SIGTYPE OP_CHECKSIGALT
+    #
+    # The only two currently supported alternative signature types are ed25519
+    # and schnorr + secp256k1 (with a compressed pubkey).
+    #
+    #  OP_DATA_32 <32-byte pubkey> <1-byte ed25519 sigtype> OP_CHECKSIGALT
+    #  OP_DATA_33 <33-byte pubkey> <1-byte schnorr+secp sigtype> OP_CHECKSIGALT
+
+    # The script can't possibly be a pay-to-alt-pubkey script if it doesn't
+    # end with OP_CHECKSIGALT or have at least two small integer pushes
+    # preceding it (although any reasonable pubkey will certainly be larger).
+    # Fail fast to avoid more work below.
+    if len(script) < 3 or script[-1] != opcode.OP_CHECKSIGALT:
+        return None, 0
+
+    if (
+        len(script) == 35
+        and script[0]
+        and opcode.OP_DATA_32
+        and isSmallInt(script[33])
+        and asSmallInt(script[33]) == crypto.STEd25519
+    ):
+        return script[1:33], crypto.STEd25519
+
+    if (
+        len(script) == 36
+        and script[0] == opcode.OP_DATA_33
+        and isSmallInt(script[34])
+        and asSmallInt(script[34]) == crypto.STSchnorrSecp256k1
+        and isStrictPubKeyEncoding(script[1:34])
+    ):
+        return script[1:34], crypto.STSchnorrSecp256k1
+
+    return None, 0
+
+
+def isPubKeyHashAltScript(script):
+    """
+    isPubKeyHashAltScript returns whether or not the passed script is a standard
+    pay-to-alt-pubkey-hash script.
+    """
+    pk, _ = extractPubKeyHashAltDetails(script)
+    return pk is not None
+
+
+def isStandardAltSignatureType(op):
+    """
+    isStandardAltSignatureType returns whether or not the provided opcode
+    represents a push of a standard alt signature type.
+    """
+    if not isSmallInt(op):
+        return False
+
+    sigType = asSmallInt(op)
+    return sigType == crypto.STEd25519 or sigType == crypto.STSchnorrSecp256k1
+
+
+def extractPubKeyHashAltDetails(script):
+    """
+    extractPubKeyHashAltDetails extracts the public key hash and signature type
+    from the passed script if it is a standard pay-to-alt-pubkey-hash script.  It
+    will return None otherwise.
+
+    Args:
+        script (bytes-like): The script to extract from.
+
+    Returns:
+        (bytes-like): The pubkey hash or None.
+        (int): The signature type or None.
+    """
+    # A pay-to-alt-pubkey-hash script is of the form:
+    #  DUP HASH160 <20-byte hash> EQUALVERIFY SIGTYPE CHECKSIG
+    #
+    # The only two currently supported alternative signature types are ed25519
+    # and schnorr + secp256k1 (with a compressed pubkey).
+    #
+    #  DUP HASH160 <20-byte hash> EQUALVERIFY <1-byte ed25519 sigtype> CHECKSIG
+    #  DUP HASH160 <20-byte hash> EQUALVERIFY <1-byte schnorr+secp sigtype> CHECKSIG
+    #
+    #  Notice that OP_0 is not specified since signature type 0 disabled.
+    if (
+        len(script) == 26
+        and script[0] == opcode.OP_DUP
+        and script[1] == opcode.OP_HASH160
+        and script[2] == opcode.OP_DATA_20
+        and script[23] == opcode.OP_EQUALVERIFY
+        and isStandardAltSignatureType(script[24])
+        and script[25] == opcode.OP_CHECKSIGALT
+    ):
+        return script[3:23], asSmallInt(script[24])
+
+    return None, 0
 
 
 def isPubKeyHashScript(script):
@@ -2486,7 +2603,7 @@ def scriptHashToAddrs(scriptHash, params):
     return [crypto.newAddressScriptHashFromHash(scriptHash, params)]
 
 
-def extractPkScriptAddrs(version, pkScript, chainParams):
+def extractPkScriptAddrs(version, pkScript, netParams):
     """
     extractPkScriptAddrs returns the type of script, addresses and required
     signatures associated with the passed PkScript.  Note that it only works for
@@ -2503,20 +2620,43 @@ def extractPkScriptAddrs(version, pkScript, chainParams):
     # Check for pay-to-pubkey-hash script.
     pkHash = extractPubKeyHash(pkScript)
     if pkHash:
-        return PubKeyHashTy, pubKeyHashToAddrs(pkHash, chainParams), 1
+        return PubKeyHashTy, pubKeyHashToAddrs(pkHash, netParams), 1
 
     # Check for pay-to-script-hash.
     scriptHash = extractScriptHash(pkScript)
     if scriptHash:
-        return ScriptHashTy, scriptHashToAddrs(scriptHash, chainParams), 1
+        return ScriptHashTy, scriptHashToAddrs(scriptHash, netParams), 1
+
+    # Check for pay-to-alt-pubkey-hash script.
+    data, sigType = extractPubKeyHashAltDetails(pkScript)
+    if data:
+        addrs = []
+        addr = crypto.newAddressPubKeyHash(data, netParams, sigType)
+        addrs.append(addr)
+        return PubkeyHashAltTy, addrs, 1
 
     # Check for pay-to-pubkey script.
     data = extractPubKey(pkScript)
     if data:
         addrs = []
         pk = Curve.parsePubKey(data)
-        addrs = [crypto.AddressSecpPubKey(pk.serializeCompressed(), chainParams)]
+        addrs = [crypto.AddressSecpPubKey(pk.serializeCompressed(), netParams)]
         return PubKeyTy, addrs, 1
+
+    # Check for pay-to-alt-pubkey script.
+    pk, sigType = extractPubKeyAltDetails(pkScript)
+    if pk:
+        raise NotImplementedError("only secp256k1 signatures are currently supported")
+        # addrs = []
+        # if sigType == dcrec.STEd25519:
+        #     addr = crypto.NewAddressEdwardsPubKey(pk, netParams)
+        #     addrs.append(addr)
+
+        # elif sigType == crypto.STSchnorrSecp256k1:
+        #     addr = crypto.NewAddressSecSchnorrPubKey(pk, netParams)
+        #     addrs.append(addr)
+
+        # return PubkeyAltTy, addrs, 1
 
     # Check for multi-signature script.
     details = extractMultisigScriptDetails(version, pkScript, True)
@@ -2525,49 +2665,53 @@ def extractPkScriptAddrs(version, pkScript, chainParams):
         addrs = []
         for encodedPK in details.pubKeys:
             pk = Curve.parsePubKey(encodedPK)
-            addrs.append(
-                crypto.AddressSecpPubKey(pk.serializeCompressed(), chainParams)
-            )
+            addrs.append(crypto.AddressSecpPubKey(pk.serializeCompressed(), netParams))
         return MultiSigTy, addrs, details.requiredSigs
 
     # Check for stake submission script.  Only stake-submission-tagged
     # pay-to-pubkey-hash and pay-to-script-hash are allowed.
     pkHash = extractStakePubKeyHash(pkScript, opcode.OP_SSTX)
     if pkHash:
-        return StakeSubmissionTy, pubKeyHashToAddrs(pkHash, chainParams), 1
+        return StakeSubmissionTy, pubKeyHashToAddrs(pkHash, netParams), 1
     scriptHash = extractStakeScriptHash(pkScript, opcode.OP_SSTX)
     if scriptHash:
-        return StakeSubmissionTy, scriptHashToAddrs(scriptHash, chainParams), 1
+        return StakeSubmissionTy, scriptHashToAddrs(scriptHash, netParams), 1
 
     # Check for stake generation script.  Only stake-generation-tagged
     # pay-to-pubkey-hash and pay-to-script-hash are allowed.
     pkHash = extractStakePubKeyHash(pkScript, opcode.OP_SSGEN)
     if pkHash:
-        return StakeGenTy, pubKeyHashToAddrs(pkHash, chainParams), 1
+        return StakeGenTy, pubKeyHashToAddrs(pkHash, netParams), 1
     scriptHash = extractStakeScriptHash(pkScript, opcode.OP_SSGEN)
     if scriptHash:
-        return StakeGenTy, scriptHashToAddrs(scriptHash, chainParams), 1
+        return StakeGenTy, scriptHashToAddrs(scriptHash, netParams), 1
 
     # Check for stake revocation script.  Only stake-revocation-tagged
     # pay-to-pubkey-hash and pay-to-script-hash are allowed.
     pkHash = extractStakePubKeyHash(pkScript, opcode.OP_SSRTX)
     if pkHash:
-        return StakeRevocationTy, pubKeyHashToAddrs(pkHash, chainParams), 1
+        return StakeRevocationTy, pubKeyHashToAddrs(pkHash, netParams), 1
     scriptHash = extractStakeScriptHash(pkScript, opcode.OP_SSRTX)
     if scriptHash:
-        return StakeRevocationTy, scriptHashToAddrs(scriptHash, chainParams), 1
+        return StakeRevocationTy, scriptHashToAddrs(scriptHash, netParams), 1
 
     # Check for stake change script.  Only stake-change-tagged
     # pay-to-pubkey-hash and pay-to-script-hash are allowed.
     pkHash = extractStakePubKeyHash(pkScript, opcode.OP_SSTXCHANGE)
     if pkHash:
-        return StakeSubChangeTy, pubKeyHashToAddrs(pkHash, chainParams), 1
+        return StakeSubChangeTy, pubKeyHashToAddrs(pkHash, netParams), 1
     scriptHash = extractStakeScriptHash(pkScript, opcode.OP_SSTXCHANGE)
     if scriptHash:
-        return StakeSubChangeTy, scriptHashToAddrs(scriptHash, chainParams), 1
+        return StakeSubChangeTy, scriptHashToAddrs(scriptHash, netParams), 1
 
-    # EVERYTHING AFTER TIHS IS UN-IMPLEMENTED
-    raise NotImplementedError("unsupported script")
+    # Check for null data script.
+    if isNullDataScript(version, pkScript):
+        # Null data transactions have no addresses or required signatures.
+        return NullDataTy, [], 0
+
+    # Don't attempt to extract addresses or required signatures for nonstandard
+    # transactions.
+    return NonStandardTy, [], 0
 
 
 def sign(chainParams, tx, idx, subScript, hashType, keysource, sigType):

--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -848,7 +848,7 @@ def extractPubKeyAltDetails(script):
 
     Returns:
         (bytes-like): The pubkey or None.
-        (int): The signature type or None.
+        (int): The signature type or 0.
     """
     # A pay-to-alt-pubkey script is of the form:
     #  PUBKEY SIGTYPE OP_CHECKSIGALT
@@ -905,7 +905,7 @@ def isStandardAltSignatureType(op):
         return False
 
     sigType = asSmallInt(op)
-    return sigType == crypto.STEd25519 or sigType == crypto.STSchnorrSecp256k1
+    return sigType in (crypto.STEd25519, crypto.STSchnorrSecp256k1)
 
 
 def extractPubKeyHashAltDetails(script):
@@ -919,7 +919,7 @@ def extractPubKeyHashAltDetails(script):
 
     Returns:
         (bytes-like): The pubkey hash or None.
-        (int): The signature type or None.
+        (int): The signature type or 0.
     """
     # A pay-to-alt-pubkey-hash script is of the form:
     #  DUP HASH160 <20-byte hash> EQUALVERIFY SIGTYPE CHECKSIG
@@ -2630,15 +2630,12 @@ def extractPkScriptAddrs(version, pkScript, netParams):
     # Check for pay-to-alt-pubkey-hash script.
     data, sigType = extractPubKeyHashAltDetails(pkScript)
     if data:
-        addrs = []
-        addr = crypto.newAddressPubKeyHash(data, netParams, sigType)
-        addrs.append(addr)
+        addrs = [crypto.newAddressPubKeyHash(data, netParams, sigType)]
         return PubkeyHashAltTy, addrs, 1
 
     # Check for pay-to-pubkey script.
     data = extractPubKey(pkScript)
     if data:
-        addrs = []
         pk = Curve.parsePubKey(data)
         addrs = [crypto.AddressSecpPubKey(pk.serializeCompressed(), netParams)]
         return PubKeyTy, addrs, 1

--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -868,8 +868,7 @@ def extractPubKeyAltDetails(script):
 
     if (
         len(script) == 35
-        and script[0]
-        and opcode.OP_DATA_32
+        and script[0] == opcode.OP_DATA_32
         and isSmallInt(script[33])
         and asSmallInt(script[33]) == crypto.STEd25519
     ):

--- a/decred/tests/unit/dcr/test_txscript.py
+++ b/decred/tests/unit/dcr/test_txscript.py
@@ -2754,7 +2754,7 @@ class TestTxScript(unittest.TestCase):
                 reqSigs=0,
                 scriptClass=txscript.NonStandardTy,
             ),
-            # Note the technically the pubkey is the second item on the
+            # Note that technically the pubkey is the second item on the
             # stack, but since the address extraction intentionally only
             # works with standard PkScripts, this should not return any
             # addresses.
@@ -2820,14 +2820,12 @@ class TestTxScript(unittest.TestCase):
 
         def checkAddrs(a, b, name):
             assert len(a) == len(b), (
-                f"extracted address length mismatch. expected %d, got %d"
-                % (len(a), len(b))
+                f"extracted address length mismatch. expected {len(a)}, got {len(b)} for test {name}"
             )
 
             for av, bv in zip(a, b):
                 assert av.scriptAddress() == bv.scriptAddress(), (
-                    f"scriptAddress mismatch. expected %s, got %s (%s)"
-                    % (av.scriptAddress().hex(), bv.scriptAddress().hex(), name)
+                    f"scriptAddress mismatch. expected {av.scriptAddress().hex()}, got {bv.scriptAddress().hex()} for test {name}"
                 )
 
         for test in tests:

--- a/decred/tests/unit/dcr/test_txscript.py
+++ b/decred/tests/unit/dcr/test_txscript.py
@@ -2560,7 +2560,6 @@ class TestTxScript(unittest.TestCase):
 
     def test_extract_script_addrs(self):
         scriptVersion = 0
-        tests = []
 
         def pkAddr(b):
             addr = crypto.AddressSecpPubKey(b, mainnet)
@@ -2568,25 +2567,16 @@ class TestTxScript(unittest.TestCase):
             addr.pubkeyFormat = crypto.PKFCompressed
             return addr
 
-        class test:
-            def __init__(
-                self,
-                name="",
-                script=b"",
-                addrs=None,
-                reqSigs=-1,
-                scriptClass=-1,
-                exception=None,
-            ):
-                self.name = name
-                self.script = script
-                self.addrs = addrs if addrs else []
-                self.reqSigs = reqSigs
-                self.scriptClass = scriptClass
-                self.exception = exception
-
-        tests.append(
-            test(
+        """
+        name (str): Short description of the test.
+        script (ByteArray): The script to test.
+        addrs (list(crypto.AddressSecpPubKey)): Expected returned addresses.
+        reqSigs (int): Expected returned required signatures.
+        scriptClass (int): expected returned signature class.
+        exception (Exception): The expected exception if present.
+        """
+        tests = [
+            dict(
                 name="standard p2pk with compressed pubkey (0x02)",
                 script=ByteArray(
                     "2102192d74d0cb94344c9569c2e77901573d8d7903c3ebec3a957724895dca52c6b4ac"
@@ -2600,10 +2590,8 @@ class TestTxScript(unittest.TestCase):
                 ],
                 reqSigs=1,
                 scriptClass=txscript.PubKeyTy,
-            )
-        )
-        tests.append(
-            test(
+            ),
+            dict(
                 name="standard p2pk with uncompressed pubkey (0x04)",
                 script=ByteArray(
                     "410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5"
@@ -2619,10 +2607,8 @@ class TestTxScript(unittest.TestCase):
                 ],
                 reqSigs=1,
                 scriptClass=txscript.PubKeyTy,
-            )
-        )
-        tests.append(
-            test(
+            ),
+            dict(
                 name="standard p2pk with compressed pubkey (0x03)",
                 script=ByteArray(
                     "2103b0bd634234abbb1ba1e986e884185c61cf43e001f9137f23c2c409273eb16e65ac"
@@ -2636,10 +2622,8 @@ class TestTxScript(unittest.TestCase):
                 ],
                 reqSigs=1,
                 scriptClass=txscript.PubKeyTy,
-            )
-        )
-        tests.append(
-            test(
+            ),
+            dict(
                 name="2nd standard p2pk with uncompressed pubkey (0x04)",
                 script=ByteArray(
                     "4104b0bd634234abbb1ba1e986e884185c61cf43e001f9137f23c2c409273eb16e6"
@@ -2655,10 +2639,8 @@ class TestTxScript(unittest.TestCase):
                 ],
                 reqSigs=1,
                 scriptClass=txscript.PubKeyTy,
-            )
-        )
-        tests.append(
-            test(
+            ),
+            dict(
                 name="standard p2pkh",
                 script=ByteArray("76a914ad06dd6ddee55cbca9a9e3713bd7587509a3056488ac"),
                 addrs=[
@@ -2670,10 +2652,8 @@ class TestTxScript(unittest.TestCase):
                 ],
                 reqSigs=1,
                 scriptClass=txscript.PubKeyHashTy,
-            )
-        )
-        tests.append(
-            test(
+            ),
+            dict(
                 name="standard p2sh",
                 script=ByteArray("a91463bcc565f9e68ee0189dd5cc67f1b0e5f02f45cb87"),
                 addrs=[
@@ -2683,11 +2663,9 @@ class TestTxScript(unittest.TestCase):
                 ],
                 reqSigs=1,
                 scriptClass=txscript.ScriptHashTy,
-            )
-        )
-        # from real tx 60a20bd93aa49ab4b28d514ec10b06e1829ce6818ec06cd3aabd013ebcdc4bb1, vout 0
-        tests.append(
-            test(
+            ),
+            # from real tx 60a20bd93aa49ab4b28d514ec10b06e1829ce6818ec06cd3aabd013ebcdc4bb1, vout 0
+            dict(
                 name="standard 1 of 2 multisig",
                 script=ByteArray(
                     "514104cc71eb30d653c0c3163990c47b976f3fb3f37cccdcbedb169a1"
@@ -2714,11 +2692,9 @@ class TestTxScript(unittest.TestCase):
                 ],
                 reqSigs=1,
                 scriptClass=txscript.MultiSigTy,
-            )
-        )
-        # from real tx d646f82bd5fbdb94a36872ce460f97662b80c3050ad3209bef9d1e398ea277ab, vin 1
-        tests.append(
-            test(
+            ),
+            # from real tx d646f82bd5fbdb94a36872ce460f97662b80c3050ad3209bef9d1e398ea277ab, vin 1
+            dict(
                 name="standard 2 of 3 multisig",
                 script=ByteArray(
                     "524104cb9c3c222c5f7a7d3b9bd152f363a0b6d54c9eb312c4d4f9af1e"
@@ -2754,41 +2730,35 @@ class TestTxScript(unittest.TestCase):
                 ],
                 reqSigs=2,
                 scriptClass=txscript.MultiSigTy,
-            )
-        )
-
-        # The below are nonstandard script due to things such as
-        # invalid pubkeys, failure to parse, and not being of a
-        # standard form.
-
-        tests.append(
-            test(
+            ),
+            # The below are nonstandard script due to things such as
+            # invalid pubkeys, failure to parse, and not being of a
+            # standard form.
+            dict(
                 name="p2pk with uncompressed pk missing OP_CHECKSIG",
                 script=ByteArray(
                     "410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a"
                     "5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3"
                 ),
                 addrs=[],
-                exception="unsupported script",
-            )
-        )
-        tests.append(
-            test(
+                reqSigs=0,
+                scriptClass=txscript.NonStandardTy,
+            ),
+            dict(
                 name="valid signature from a sigscript - no addresses",
                 script=ByteArray(
                     "47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd"
                     "410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901"
                 ),
                 addrs=[],
-                exception="unsupported script",
-            )
-        )
-        # Note the technically the pubkey is the second item on the
-        # stack, but since the address extraction intentionally only
-        # works with standard PkScripts, this should not return any
-        # addresses.
-        tests.append(
-            test(
+                reqSigs=0,
+                scriptClass=txscript.NonStandardTy,
+            ),
+            # Note the technically the pubkey is the second item on the
+            # stack, but since the address extraction intentionally only
+            # works with standard PkScripts, this should not return any
+            # addresses.
+            dict(
                 name="valid sigscript to redeem p2pk - no addresses",
                 script=ByteArray(
                     "493046022100ddc69738bf2336318e4e041a5a77f305da87428ab1606"
@@ -2799,14 +2769,12 @@ class TestTxScript(unittest.TestCase):
                 ),
                 addrs=[],
                 reqSigs=0,
-                exception="unsupported script",
-            )
-        )
-        # adapted from btc:
-        # tx 691dd277dc0e90a462a3d652a1171686de49cf19067cd33c7df0392833fb986a, vout 0
-        # invalid public keys
-        tests.append(
-            test(
+                scriptClass=txscript.NonStandardTy,
+            ),
+            # adapted from btc:
+            # tx 691dd277dc0e90a462a3d652a1171686de49cf19067cd33c7df0392833fb986a, vout 0
+            # invalid public keys
+            dict(
                 name="1 of 3 multisig with invalid pubkeys",
                 script=ByteArray(
                     "5141042200007353455857696b696c65616b73204361626c6567617465"
@@ -2817,15 +2785,12 @@ class TestTxScript(unittest.TestCase):
                     "680a63616e20626520666f756e6420696e207472616e73616374696f6e"
                     "2036633533636439383731313965663739376435616463636453ae"
                 ),
-                addrs=[],
-                exception="isn't on secp256k1 curve",
-            )
-        )
-        # adapted from btc:
-        # tx 691dd277dc0e90a462a3d652a1171686de49cf19067cd33c7df0392833fb986a, vout 44
-        # invalid public keys
-        tests.append(
-            test(
+                exception=DecredError,
+            ),
+            # adapted from btc:
+            # tx 691dd277dc0e90a462a3d652a1171686de49cf19067cd33c7df0392833fb986a, vout 44
+            # invalid public keys
+            dict(
                 name="1 of 3 multisig with invalid pubkeys 2",
                 script=ByteArray(
                     "514104633365633235396337346461636536666430383862343463656"
@@ -2835,57 +2800,53 @@ class TestTxScript(unittest.TestCase):
                     "303963353933633365393166656465373032392102323364643432643"
                     "235363339643338613663663530616234636434340a00000053ae"
                 ),
-                addrs=[],
-                exception="isn't on secp256k1 curve",
-            )
-        )
-        tests.append(
-            test(
+                exception=DecredError,
+            ),
+            dict(
                 name="empty script",
                 script=ByteArray(b""),
                 addrs=[],
                 reqSigs=0,
-                exception="unsupported script",
-            )
-        )
-        tests.append(
-            test(
+                scriptClass=txscript.NonStandardTy,
+            ),
+            dict(
                 name="script that does not parse",
                 script=ByteArray([opcode.OP_DATA_45]),
                 addrs=[],
                 reqSigs=0,
-                exception="unsupported script",
-            )
-        )
+                scriptClass=txscript.NonStandardTy,
+            ),
+        ]
 
         def checkAddrs(a, b, name):
-            if len(a) != len(b):
-                t.fail(
-                    "extracted address length mismatch. expected %d, got %d"
-                    % (len(a), len(b))
-                )
+            assert len(a) == len(b), (
+                f"extracted address length mismatch. expected %d, got %d"
+                % (len(a), len(b))
+            )
+
             for av, bv in zip(a, b):
-                if av.scriptAddress() != bv.scriptAddress():
-                    self.fail(
-                        "scriptAddress mismatch. expected %s, got %s (%s)"
-                        % (av.scriptAddress().hex(), bv.scriptAddress().hex(), name)
-                    )
-
-        for i, t in enumerate(tests):
-            try:
-                scriptClass, addrs, reqSigs = txscript.extractPkScriptAddrs(
-                    scriptVersion, t.script, mainnet
+                assert av.scriptAddress() == bv.scriptAddress(), (
+                    f"scriptAddress mismatch. expected %s, got %s (%s)"
+                    % (av.scriptAddress().hex(), bv.scriptAddress().hex(), name)
                 )
-            except (DecredError, NotImplementedError) as e:
-                if t.exception and t.exception in str(e):
-                    continue
-                self.fail("extractPkScriptAddrs #%d (%s): %s" % (i, t.name, e))
 
-            self.assertEqual(scriptClass, t.scriptClass, t.name)
+        for test in tests:
+            if "exception" in test:
+                with pytest.raises(test["exception"]):
+                    scriptClass, addrs, reqSigs = txscript.extractPkScriptAddrs(
+                        scriptVersion, test["script"], mainnet
+                    )
+                continue
 
-            self.assertEqual(reqSigs, t.reqSigs, t.name)
+            scriptClass, addrs, reqSigs = txscript.extractPkScriptAddrs(
+                scriptVersion, test["script"], mainnet
+            )
 
-            checkAddrs(t.addrs, addrs, t.name)
+            self.assertEqual(scriptClass, test["scriptClass"], test["name"])
+
+            self.assertEqual(reqSigs, test["reqSigs"], test["name"])
+
+            checkAddrs(test["addrs"], addrs, test["name"])
 
     def test_pay_to_addr_script(self):
         """


### PR DESCRIPTION
Add checks for PubkeyHashAltTy, PubkeyAltTy, and NullDataTy. Return
NonStandardTy rather than throw an exception if no types match. This
copies dcrd's functioning.

Update tests and use a dictionary rather than a test class.

Uncomment appropriate places in getScriptClass.

account method no longer checks for an Exception.

Also changed chainParams to netParams.