### PR TITLE
tests: more test coverage

### DIFF
--- a/decred/decred/crypto/secp256k1/curve.py
+++ b/decred/decred/crypto/secp256k1/curve.py
@@ -383,8 +383,8 @@ class KoblitzCurve:
 
     def decompressPoint(self, x, ybit):
         """
-        decompressPoint decompresses a point on the given curve given the X point and
-        the solution to use.
+        decompressPoint decompresses a point on the given curve given
+        the X point and the solution to use.
         """
         # TODO(oga) This will probably only work for secp256k1 due to
         # optimizations.
@@ -400,7 +400,7 @@ class KoblitzCurve:
         if ybit == isEven(y):
             y = self.P - y
         if ybit == isEven(y):
-            raise DecredError("ybit doesn't match oddnes")
+            raise DecredError("ybit doesn't match oddness")
         return y
 
     def addJacobian(self, x1, y1, z1, x2, y2, z2, x3, y3, z3):  # *fieldVal) {

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -42,7 +42,7 @@ class DcrdataError(DecredError):
 class DcrdataPath:
     """
     DcrdataPath represents some point along a URL. It may just be a node that
-    is not an endpoint, or it may be an enpoint, in which case it's `get`
+    is not an endpoint, or it may be an endpoint, in which case its `get`
     method will be a valid api call. If it is a node of a longer URL,
     the following nodes are available as attributes. e.g. if this is node A
     along the URL base/A/B, then node B is available as client.A.B.
@@ -117,8 +117,8 @@ InsightPaths = [
 
 class DcrdataClient:
     """
-    DcrdataClient represents the base node. The only argument to the
-    constructor is the path to a DCRData server, e.g. http://explorer.dcrdata.org.
+    DcrdataClient represents the base node. The only argument to the constructor
+    is the path to a DCRData server, e.g. http://explorer.dcrdata.org.
     """
 
     timeFmt = "%Y-%m-%d %H:%M:%S"
@@ -351,9 +351,8 @@ def checkOutput(output, fee):
         output (TxOut): The output to check
         fee (float): The transaction fee rate (/kB).
 
-    Returns:
-        There is no return value. If an output is deemed invalid, DecredError
-        is raised.
+    Raises:
+        DecredError if an output is deemed invalid.
     """
     if output.value < 0:
         raise DecredError("transaction output amount is negative")

--- a/decred/decred/util/encode.py
+++ b/decred/decred/util/encode.py
@@ -281,7 +281,7 @@ class ByteArray(object):
     def __setitem__(self, i, v):
         v = decodeBA(v, copy=False)
         if i + len(v) > len(self.b):
-            raise AssertionError("source bytes too long")
+            raise DecredError("source bytes too long")
         for j in range(len(v)):
             self.b[i + j] = v[j]
 
@@ -378,7 +378,7 @@ class BuildyBytes(ByteArray):
         lenBytes = intToBytes(len(d))
         bLen = len(lenBytes)
         if bLen > 2:
-            raise AssertionError("cannot push data longer than 65535")
+            raise DecredError("cannot push data longer than 65535")
         if bLen == 2:
             lBytes = bytearray((0xFF, lenBytes[0], lenBytes[1]))
         elif bLen == 1:

--- a/decred/tests/unit/crypto/secp256k1/test_curve.py
+++ b/decred/tests/unit/crypto/secp256k1/test_curve.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2019, the Decred developers
+Copyright (c) 2019-2020, the Decred developers
 See LICENSE for details
 """
 
@@ -774,6 +774,11 @@ def test_public_keys():
                 0xa6, 0x85, 0x54, 0x19, 0x9c, 0x47, 0xd0, 0x8f, 0xfb,
                 0x10, 0xd4, 0xb8,
             )),
+            isValid=False,
+        ),
+        dict(
+            name="empty",
+            key=bytes(),
             isValid=False,
         ),
     ]

--- a/decred/tests/unit/dcr/test_agenda.py
+++ b/decred/tests/unit/dcr/test_agenda.py
@@ -3,7 +3,7 @@ Copyright (c) 2020, the Decred developers
 See LICENSE for details
 """
 
-from decred.dcr import agenda
+from decred.dcr.agenda import Agenda, AgendaChoices, AgendaInfo, AgendasInfo
 
 
 AGENDA_INFO_RAW = dict(status="defined", since=1, starttime=2, expiretime=3,)
@@ -19,7 +19,7 @@ AGENDA_INFO_ATTRS = (
 
 def test_agenda_info():
     do_test(
-        agenda.AgendaInfo, AGENDA_INFO_RAW, AGENDA_INFO_PARSED, AGENDA_INFO_ATTRS,
+        AgendaInfo, AGENDA_INFO_RAW, AGENDA_INFO_PARSED, AGENDA_INFO_ATTRS,
     )
 
 
@@ -47,10 +47,7 @@ AGENDA_CHOICES_ATTRS = (
 
 def test_agenda_choices():
     do_test(
-        agenda.AgendaChoices,
-        AGENDA_CHOICES_RAW,
-        AGENDA_CHOICES_PARSED,
-        AGENDA_CHOICES_ATTRS,
+        AgendaChoices, AGENDA_CHOICES_RAW, AGENDA_CHOICES_PARSED, AGENDA_CHOICES_ATTRS,
     )
 
 
@@ -66,7 +63,7 @@ AGENDA_RAW = dict(
 )
 # Make a copy of the raw dict in order not to overwrite it.
 AGENDA_PARSED = dict(AGENDA_RAW)
-AGENDA_PARSED["choices"] = [agenda.AgendaChoices.parse(AGENDA_CHOICES_RAW)]
+AGENDA_PARSED["choices"] = [AgendaChoices.parse(AGENDA_CHOICES_RAW)]
 AGENDA_ATTRS = (
     "id",
     "description",
@@ -81,7 +78,7 @@ AGENDA_ATTRS = (
 
 def test_agenda():
     do_test(
-        agenda.Agenda, AGENDA_RAW, AGENDA_PARSED, AGENDA_ATTRS,
+        Agenda, AGENDA_RAW, AGENDA_PARSED, AGENDA_ATTRS,
     )
 
 
@@ -97,7 +94,7 @@ AGENDAS_INFO_RAW = {
 }
 # Make a copy of the raw dict in order not to overwrite it.
 AGENDAS_INFO_PARSED = dict(AGENDAS_INFO_RAW)
-AGENDAS_INFO_PARSED["agendas"] = [agenda.Agenda.parse(AGENDA_RAW)]
+AGENDAS_INFO_PARSED["agendas"] = [Agenda.parse(AGENDA_RAW)]
 AGENDAS_INFO_ATTRS = (
     "currentHeight",
     "startHeight",
@@ -112,7 +109,7 @@ AGENDAS_INFO_ATTRS = (
 
 def test_agendas_info():
     do_test(
-        agenda.AgendasInfo, AGENDAS_INFO_RAW, AGENDAS_INFO_PARSED, AGENDAS_INFO_ATTRS,
+        AgendasInfo, AGENDAS_INFO_RAW, AGENDAS_INFO_PARSED, AGENDAS_INFO_ATTRS,
     )
 
 
@@ -128,3 +125,17 @@ def do_test(class_, raw, parsed, attrs):
     obj = class_.parse(raw)
     for attr in attrs:
         assert getattr(obj, attr) == parsed[attr.lower()]
+
+
+def test_eq():
+    # AgendaChoices
+    choices = AgendaChoices.parse(AGENDA_CHOICES_RAW)
+    assert choices != object()
+    choices2 = AgendaChoices.parse(AGENDA_CHOICES_RAW)
+    assert choices == choices2
+
+    # Agenda
+    agenda = Agenda.parse(AGENDA_RAW)
+    assert agenda != object()
+    agenda2 = Agenda.parse(AGENDA_RAW)
+    assert agenda == agenda2

--- a/decred/tests/unit/util/test_encode.py
+++ b/decred/tests/unit/util/test_encode.py
@@ -1,18 +1,15 @@
 """
-Copyright (c) 2019, the Decred developers
+Copyright (c) 2019-2020, the Decred developers
 See LICENSE for details
 """
 
-import unittest
+import pytest
 
-from decred.util import encode
-
-
-ByteArray = encode.ByteArray
-BuildyBytes = encode.BuildyBytes
+from decred import DecredError
+from decred.util.encode import BuildyBytes, ByteArray, decodeBlob, extractPushes
 
 
-class TestEncode(unittest.TestCase):
+class TestEncode:
     def test_ByteArray(self):
         makeA = lambda: ByteArray([0, 0, 255])
         makeB = lambda: ByteArray([0, 255, 0])
@@ -22,82 +19,109 @@ class TestEncode(unittest.TestCase):
         a = makeA()
         b = makeB()
         a |= b
-        self.assertEqual(a, bytearray([0, 255, 255]))
+        assert a == bytearray([0, 255, 255])
 
         c = makeC()
         a &= c
-        self.assertEqual(a, zero)
+        assert a == zero
 
         a = makeA()
         a.zero()
-        self.assertEqual(a, zero)
+        assert a == zero
 
         c = makeA()
         c |= 0
-        self.assertEqual(a, zero)
+        assert a == zero
 
         a = makeA()
         c = makeC()
-        self.assertEqual(a & c, zero)
+        assert a & c == zero
 
-        self.assertFalse(makeA().iseven())
-        self.assertTrue(makeB().iseven())
-        self.assertTrue(makeC().iseven())
-        self.assertTrue(zero.iseven())
+        assert makeA().iseven() is False
+        assert makeB().iseven()
+        assert makeC().iseven()
+        assert zero.iseven()
 
         zero2 = ByteArray(zero)
-        self.assertFalse(zero.b is zero2.b)
-        self.assertEqual(zero, zero2)
+        assert zero.b is not zero2.b
+        assert zero == zero2
 
         zero2 = ByteArray(zero, copy=False)
-        self.assertTrue(zero.b is zero2.b)
+        assert zero.b is zero2.b
 
         a = makeA()
         a |= makeC()
         a |= 65280
-        self.assertEqual(a, bytearray([255, 255, 255]))
-        self.assertFalse(a == makeB())
-        self.assertFalse(a == None)  # noqa
+        assert a == bytearray([255, 255, 255])
+        assert a != makeB()
+        assert a != None  # noqa
 
-        self.assertTrue(makeA() < makeB())
-        self.assertTrue(makeC() > makeB())
-        self.assertTrue(makeA() != makeB())
-        self.assertTrue(makeA() != None)  # noqa
-        self.assertTrue(makeA() <= makeA())
-        self.assertTrue(makeB() >= makeA())
+        assert makeA() < makeB()
+        assert makeC() > makeB()
+        assert makeA() != makeB()
+        assert not (makeA() == None)  # noqa
+        assert makeA() != None  # noqa
+        assert makeA() <= makeA()
+        assert makeB() >= makeA()
 
         a = makeA()
         a2 = ByteArray(zero)
         a2 |= a[2:]
-        self.assertTrue(a is not a2)
-        self.assertEqual(a, a2)
-        self.assertEqual(a[2], 255)
+        assert a is not a2
+        assert a == a2
+        assert a[2] == 255
 
         z = ByteArray(zero)
         z[2] = 255
-        self.assertEqual(makeA(), z)
+        assert makeA() == z
 
         # encode.Blobber API
-        self.assertIsInstance(ByteArray.unblob(zero), ByteArray)
-        self.assertEqual(ByteArray.blob(zero), zero.b)
+        assert isinstance(ByteArray.unblob(zero), ByteArray)
+        assert ByteArray.blob(zero) == zero.b
+
+        with pytest.raises(DecredError):
+            zero[3] = 0
 
     def test_BuildyBytes(self):
-        self.assertEqual(BuildyBytes().hex(), "")
+        assert BuildyBytes().hex() == ""
 
         d0 = ByteArray([0x01, 0x02])
         d1 = ByteArray([0x03, 0x04, 0x05])
         d2 = ByteArray(b"")
         res = BuildyBytes(0).addData(d0).addData(d1).addData(d2)
         exp = ByteArray([0x00, 0x02, 0x01, 0x02, 0x03, 0x03, 0x04, 0x05, 0x00])
-        self.assertEqual(res, exp)
+        assert res == exp
 
         # Now do a versioned blob with a data push > 255 bytes.
         dBig = ByteArray(b"", length=257)
         dBig[100] = 0x12
         res = BuildyBytes(5).addData(d0).addData(d1).addData(d2).addData(dBig)
-        ver, pushes = encode.decodeBlob(res)
-        self.assertEqual(ver, 5)
-        self.assertEqual(d0, pushes[0])
-        self.assertEqual(d1, pushes[1])
-        self.assertEqual(d2, pushes[2])
-        self.assertEqual(dBig, pushes[3])
+        ver, pushes = decodeBlob(res)
+        assert ver == 5
+        assert d0 == pushes[0]
+        assert d1 == pushes[1]
+        assert d2 == pushes[2]
+        assert dBig == pushes[3]
+
+        dHuge = ByteArray(b"", length=65536)
+        with pytest.raises(DecredError):
+            BuildyBytes(0).addData(dHuge)
+
+    def test_decodeBlob(self):
+        with pytest.raises(DecredError):
+            decodeBlob(b"")
+        assert decodeBlob(bytes((0, 0x01, 0x02))) == (0, [b"\x02"])
+
+    def test_extractPushes(self):
+        assert len(extractPushes(b"")) == 0
+
+        with pytest.raises(DecredError):
+            extractPushes(ByteArray([0xFF]))
+
+        assert extractPushes(ByteArray([0xFF, 0x00, 0x00])) == [ByteArray()]
+
+        with pytest.raises(DecredError):
+            extractPushes(ByteArray([0x01]))
+
+        assert extractPushes(ByteArray([0x00])) == [ByteArray()]
+        assert extractPushes(ByteArray([0x01, 0x00])) == [ByteArray([0x00])]


### PR DESCRIPTION
More test coverage for various modules:

`util.encode`:
- converted to pytest format;
- coverage up to 100%;

`dcr.agenda`:
- coverage up to 100%;

`crypto.secp256k1.curve`:
- coverage up to 99%.

Part of #70.