### PR TITLE
txscript: Add addData test

### DIFF
--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -2163,7 +2163,15 @@ def addInt(val):
 
 
 def addData(data):
-    dataLen = len(data)
+    """
+    Prefaces data with the correct opcode when adding it to the stack.
+
+    Args:
+        value (ByteArray): Data to add.
+    Returns:
+        ByteArray: The data preceded with the correct opcode.
+    """
+    dataLen = len(data) if data else 0
     b = ByteArray(b"")
 
     # When the data consists of a single number that can be represented


### PR DESCRIPTION
This is missing checks for script max size and max element size. In dcrd they are part of the exported AddData function. Should I put them in?