### PR TITLE
tests: use in-memory databases

### DIFF
--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -15,7 +15,6 @@ from urllib.parse import urlencode, urlparse
 from decred import DecredError
 from decred.crypto import crypto
 from decred.util import database, tinyhttp, ws
-from decred.util.database import KeyValueDatabase
 from decred.util.encode import ByteArray
 from decred.util.helpers import formatTraceback, getLogger
 from decred.wallet import api
@@ -396,17 +395,18 @@ class DcrdataBlockchain:
     def __init__(self, db, params, datapath, skipConnect=False):
         """
         Args:
-            db (str | database.Bucket): the database bucket or a filepath.
-                If a filepath, a new database will be created.
+            db (database.Bucket | database.KeyValueDatabase | filepath):
+                the database or a filepath. If a filepath, a new database
+                will be created.
             params obj: blockchain network parameters.
             datapath str: a URI for a dcrdata server.
             skipConnect bool: skip initial connection to dcrdata.
         """
         # Allow string arguments for database.
         self.ownsDB = False
-        if isinstance(db, str):
+        if not isinstance(db, (database.Bucket, database.KeyValueDatabase)):
             self.ownsDB = True
-            db = KeyValueDatabase(db)
+            db = database.KeyValueDatabase(db)
         self.db = db
         self.params = params
         # The blockReceiver and addressReceiver will be set when the respective

--- a/decred/decred/util/database.py
+++ b/decred/decred/util/database.py
@@ -307,12 +307,13 @@ class SequencedConnection(sqlite3.Connection):
     A SequencedConnection is a sqlite3.Connection with a mutex lock.
     """
 
-    def __init__(self, *a, **k):
+    def __init__(self, filepath, *a, **k):
         """
         Constructor for a SequencedConnection. All arguments are passed
-        directly to the sqlite.Connection construtor.
+        to the sqlite.Connection construtor.
         """
-        super().__init__(*a, **k)
+        # Converting filepath to str for Python 3.6 compatibility.
+        super().__init__(str(filepath), *a, **k)
         self.mtx = threading.Lock()
 
     def lock(self):

--- a/decred/tests/integration/dcr/test_dcrdata.py
+++ b/decred/tests/integration/dcr/test_dcrdata.py
@@ -38,9 +38,9 @@ class TestDcrdata:
         client.subscribeAddresses("Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx")
         client.close()
 
-    def test_get_block_header(self, tmpdir):
+    def test_get_block_header(self):
         blockchain = dcrdata.DcrdataBlockchain(
-            tmpdir.join("db.db"), mainnet, "https://alpha.dcrdata.org"
+            ":memory:", mainnet, "https://alpha.dcrdata.org"
         )
         try:
             blockchain.connect()
@@ -50,9 +50,9 @@ class TestDcrdata:
         finally:
             blockchain.close()
 
-    def test_purchase_ticket(self, tmpdir):
+    def test_purchase_ticket(self):
         blockchain = dcrdata.DcrdataBlockchain(
-            tmpdir.join("db.db"), testnet, "https://testnet.dcrdata.org"
+            ":memory:", testnet, "https://testnet.dcrdata.org"
         )
         try:
             blockchain.connect()
@@ -147,9 +147,9 @@ class TestDcrdata:
         finally:
             blockchain.close()
 
-    def test_revoke_ticket(self, tmpdir):
+    def test_revoke_ticket(self):
         blockchain = dcrdata.DcrdataBlockchain(
-            tmpdir.join("db.db"), testnet, "https://testnet.dcrdata.org"
+            ":memory:", testnet, "https://testnet.dcrdata.org"
         )
         blockchain.connect()
 

--- a/decred/tests/integration/dcr/test_dcrdata.py
+++ b/decred/tests/integration/dcr/test_dcrdata.py
@@ -1,12 +1,9 @@
 """
-Copyright (c) 2019, the Decred developers
+Copyright (c) 2019-2020, the Decred developers
 See LICENSE for details
 """
 
-import os
-from tempfile import TemporaryDirectory
 import time
-import unittest
 
 from decred.crypto import crypto, rando
 from decred.crypto.secp256k1 import curve as Curve
@@ -20,7 +17,7 @@ def newHash():
     return ByteArray(rando.generateSeed(32))
 
 
-class TestDcrdata(unittest.TestCase):
+class TestDcrdata:
     def client(self, **k):
         return dcrdata.DcrdataClient("https://alpha.dcrdata.org", **k)
 
@@ -41,126 +38,23 @@ class TestDcrdata(unittest.TestCase):
         client.subscribeAddresses("Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx")
         client.close()
 
-    def test_get_block_header(self):
-        with TemporaryDirectory() as tempDir:
-            blockchain = dcrdata.DcrdataBlockchain(
-                os.path.join(tempDir, "db.db"), mainnet, "https://alpha.dcrdata.org"
+    def test_get_block_header(self, tmpdir):
+        blockchain = dcrdata.DcrdataBlockchain(
+            tmpdir.join("db.db"), mainnet, "https://alpha.dcrdata.org"
+        )
+        try:
+            blockchain.connect()
+            blockchain.blockHeader(
+                "298e5cc3d985bfe7f81dc135f360abe089edd4396b86d2de66b0cef42b21d980"
             )
-            try:
-                blockchain.connect()
-                blockchain.blockHeader(
-                    "298e5cc3d985bfe7f81dc135f360abe089edd4396b86d2de66b0cef42b21d980"
-                )
-            finally:
-                blockchain.close()
+        finally:
+            blockchain.close()
 
-    def test_purchase_ticket(self):
-        with TemporaryDirectory() as tempDir:
-            blockchain = dcrdata.DcrdataBlockchain(
-                os.path.join(tempDir, "db.db"), testnet, "https://testnet.dcrdata.org"
-            )
-            try:
-                blockchain.connect()
-
-                def broadcast(txHex):
-                    print("test skipping broadcast of transaction: %s" % txHex)
-                    return True
-
-                blockchain.broadcast = broadcast
-                txs = {}
-
-                def getTx(txid):
-                    return txs[txid]
-
-                blockchain.tx = getTx
-                addrs = []
-                keys = {}
-
-                def internal():
-                    privKey = Curve.generateKey()
-                    pkHash = crypto.hash160(privKey.pub.serializeCompressed().b)
-                    addr = crypto.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
-                    addrs.append(addr)
-                    keys[addr.string()] = privKey
-                    return addr.string()
-
-                def priv(addr):
-                    return keys[addr]
-
-                class KeySource:
-                    def priv(self, *a):
-                        return priv(*a)
-
-                    def internal(self):
-                        return internal()
-
-                def utxosource(amt, filter):
-                    nextVal = 10
-                    total = 0
-                    utxos = []
-
-                    while total < amt:
-                        atoms = int(nextVal * 1e8)
-                        privKey = Curve.generateKey()
-                        pkHash = crypto.hash160(privKey.pub.serializeCompressed().b)
-                        addr = crypto.AddressPubKeyHash(
-                            testnet.PubKeyHashAddrID, pkHash
-                        )
-                        addrs.append(addr)
-                        addrString = addr.string()
-                        keys[addrString] = privKey
-                        pkScript = txscript.makePayToAddrScript(addrString, testnet)
-                        txHash = newHash()
-                        txid = reversed(txHash).hex()
-                        utxos.append(
-                            account.UTXO(
-                                address=addrString,
-                                txHash=txHash,
-                                vout=0,
-                                ts=int(time.time()),
-                                scriptPubKey=pkScript,
-                                satoshis=atoms,
-                            )
-                        )
-                        tx = msgtx.MsgTx.new()
-                        tx.addTxOut(msgtx.TxOut(value=atoms, pkScript=pkScript))
-                        txs[txid] = tx
-                        total += atoms
-                        nextVal *= 2
-                    return utxos, True
-
-                poolPriv = Curve.generateKey()
-                pkHash = crypto.hash160(poolPriv.pub.serializeCompressed().b)
-                poolAddr = crypto.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
-                scriptHash = crypto.hash160("some script. doesn't matter".encode())
-                scriptAddr = crypto.AddressScriptHash(
-                    testnet.ScriptHashAddrID, scriptHash
-                )
-                ticketPrice = blockchain.stakeDiff()
-
-                request = account.TicketRequest(
-                    minConf=0,
-                    expiry=0,
-                    spendLimit=ticketPrice * 2 * 1.1,
-                    poolAddress=poolAddr.string(),
-                    votingAddress=scriptAddr.string(),
-                    ticketFee=0,
-                    poolFees=7.5,
-                    count=2,
-                    txFee=0,
-                )
-
-                ticket, spent, newUTXOs = blockchain.purchaseTickets(
-                    KeySource(), utxosource, request
-                )
-            finally:
-                blockchain.close()
-
-    def test_revoke_ticket(self):
-        with TemporaryDirectory() as tempDir:
-            blockchain = dcrdata.DcrdataBlockchain(
-                os.path.join(tempDir, "db.db"), testnet, "https://testnet.dcrdata.org"
-            )
+    def test_purchase_ticket(self, tmpdir):
+        blockchain = dcrdata.DcrdataBlockchain(
+            tmpdir.join("db.db"), testnet, "https://testnet.dcrdata.org"
+        )
+        try:
             blockchain.connect()
 
             def broadcast(txHex):
@@ -168,37 +62,195 @@ class TestDcrdata(unittest.TestCase):
                 return True
 
             blockchain.broadcast = broadcast
+            txs = {}
 
-            class test:
-                def __init__(
-                    self, ticket="", privKey="", redeemScript="", revocation="",
-                ):
-                    self.ticket = ticket
-                    self.privKey = privKey
-                    self.redeemScript = redeemScript
-                    self.revocation = revocation
+            def getTx(txid):
+                return txs[txid]
 
-            tests = [
-                test(
-                    "010000000210fd1f5623e2469d9bb390ad21b12f6710f5d6be0e130df074cfd8614d0c4e050400000000ffffffff10fd1f5623e2469d9bb390ad21b12f6710f5d6be0e130df074cfd8614d0c4e050500000000ffffffff05508f4a7401000000000018baa91438a8a93737e62e806f49d1465518a02f110d57fe8700000000000000000000206a1e1aee120db13f4e4f785aec3da97b48963de58ebd37570200000000000058000000000000000000001abd76a914000000000000000000000000000000000000000088ac00000000000000000000206a1eabc7372997a530b43e8e17a4850602b28e0768dd454d4874010000000058000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000002375702000000000000000000000000006a47304402202b5f4a97abf78d95875de75b244f9b4c7f60bb40b01a91881331022a03a3bf32022047f951e0414e4f28518b5254974abeb93f77727bee7c6fbd5010f8bf375dd10f012102ec908402cb3ab128a9a68978fbb3b33f1c97d715afb8f76dbbe300619878f095454d48740100000000000000000000006a47304402200435095049ac7b3f3c47a43d92afc22db032b929357f2f216eb24e91cd0d2d2802203ca93654cc1f193f11ce0c7e74f9959edd984c15d54f99b0d227b1cdd99a4a3e012102ec908402cb3ab128a9a68978fbb3b33f1c97d715afb8f76dbbe300619878f095",
-                    "d407f81cb789e65579590d5e50027431f1fdea21c2ebef12944b7842e71eaf",
-                    "51210289a43bf822daf338bb07555476a967cc46545a58c513a0badc99861c81f985782103b1f62148c92802a47ce98a49d1f14f397adc759131f6f6a5c88ad9dfedd53f9b52ae",
-                    "0100000001113d36ae0156c1f5a3071de1f7f10e9e4521a77266b1927f832babb9fe3d5cd90000000001ffffffff022c4d02000000000000001abc76a9141aee120db13f4e4f785aec3da97b48963de58ebd88ac193848740100000000001abc76a914abc7372997a530b43e8e17a4850602b28e0768dd88ac000000000000000001508f4a740100000000000000000000009148304502210099b8e13022e13d19229fff3a2b08ebf54f5cd4ea79c85618d04a57a735283e9102203e0fd5a66a168edff1bbcaeaa9d5b2d5e224cbd5d90a6c0099c73810d7493924014751210289a43bf822daf338bb07555476a967cc46545a58c513a0badc99861c81f985782103b1f62148c92802a47ce98a49d1f14f397adc759131f6f6a5c88ad9dfedd53f9b52ae",
-                ),
-                test(
-                    "010000000228a301cae233e252143e6fff3ccd348e156bbcc8ea158cfb4a1fe19f78cad1e80a00000000ffffffff28a301cae233e252143e6fff3ccd348e156bbcc8ea158cfb4a1fe19f78cad1e80b00000000ffffffff05d00fb2fb00000000000018baa91438a8a93737e62e806f49d1465518a02f110d57fe8700000000000000000000206a1e1aee120db13f4e4f785aec3da97b48963de58ebdcf550200000000000058000000000000000000001abd76a914000000000000000000000000000000000000000088ac00000000000000000000206a1e949293b5f8acd5a0a871ce417cd5354d9715a2912dcfaffb000000000058000000000000000000001abd76a914000000000000000000000000000000000000000088ac000000000000000002cf5502000000000000000000000000006b483045022100a4072a6a09058cf1b2713b75e636bcdf418c9897aa18cd584cfcf0229bf6b7d102200cb94cfef85a31943ab1e0daba90578c3b465be26e4a94a19e1da5ec70586193012103ac3936e6c8d0fd9cefde6cc9552289c943a1eb4abe1601de8f8e46b8f7ed508d2dcfaffb0000000000000000000000006a47304402202fc0578332b69746109066cc7d7cb9b86f0a693639bbe4dc84c83f26ef0e3bad022010ad57133bcc77bb36600488679f5da6ab6740b4d743470bcd60f2ecda70aa7f012103ac3936e6c8d0fd9cefde6cc9552289c943a1eb4abe1601de8f8e46b8f7ed508d",
-                    "d407f81cb789e65579590d5e50027431f1fdea21c2ebef12944b7842e71eaf",
-                    "51210289a43bf822daf338bb07555476a967cc46545a58c513a0badc99861c81f985782103b1f62148c92802a47ce98a49d1f14f397adc759131f6f6a5c88ad9dfedd53f9b52ae",
-                    "0100000001d033e1ddf9c44a1402d8dc8d6cfcee634a459537a078359a3c51153b7ba67b220000000001ffffffff02c44b02000000000000001abc76a9141aee120db13f4e4f785aec3da97b48963de58ebd88ac01baaffb0000000000001abc76a914949293b5f8acd5a0a871ce417cd5354d9715a29188ac000000000000000001d00fb2fb00000000000000000000000091483045022100f83aa623b21d302cdc65b6b227fe53f3796379031dd1fee9bc398680f846221d022062282396b391ba38612afea9a648b7db7ef54b0d4b06bddae7783bb25cf6ba1f014751210289a43bf822daf338bb07555476a967cc46545a58c513a0badc99861c81f985782103b1f62148c92802a47ce98a49d1f14f397adc759131f6f6a5c88ad9dfedd53f9b52ae",
-                ),
-            ]
+            blockchain.tx = getTx
+            addrs = []
+            keys = {}
 
-            for test in tests:
-                ticket = msgtx.MsgTx.deserialize(ByteArray(test.ticket))
-                keysource = account.KeySource(
-                    priv=lambda _: crypto.privKeyFromBytes(ByteArray(test.privKey)),
-                    internal=lambda: "",
-                )
-                redeemScript = ByteArray(test.redeemScript)
-                revocation = blockchain.revokeTicket(ticket, keysource, redeemScript)
-                self.assertEqual(test.revocation, revocation.txHex())
+            def internal():
+                privKey = Curve.generateKey()
+                pkHash = crypto.hash160(privKey.pub.serializeCompressed().b)
+                addr = crypto.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
+                addrs.append(addr)
+                keys[addr.string()] = privKey
+                return addr.string()
+
+            def priv(addr):
+                return keys[addr]
+
+            class KeySource:
+                def priv(self, *a):
+                    return priv(*a)
+
+                def internal(self):
+                    return internal()
+
+            def utxosource(amt, filter):
+                nextVal = 10
+                total = 0
+                utxos = []
+
+                while total < amt:
+                    atoms = int(nextVal * 1e8)
+                    privKey = Curve.generateKey()
+                    pkHash = crypto.hash160(privKey.pub.serializeCompressed().b)
+                    addr = crypto.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
+                    addrs.append(addr)
+                    addrString = addr.string()
+                    keys[addrString] = privKey
+                    pkScript = txscript.makePayToAddrScript(addrString, testnet)
+                    txHash = newHash()
+                    txid = reversed(txHash).hex()
+                    utxos.append(
+                        account.UTXO(
+                            address=addrString,
+                            txHash=txHash,
+                            vout=0,
+                            ts=int(time.time()),
+                            scriptPubKey=pkScript,
+                            satoshis=atoms,
+                        )
+                    )
+                    tx = msgtx.MsgTx.new()
+                    tx.addTxOut(msgtx.TxOut(value=atoms, pkScript=pkScript))
+                    txs[txid] = tx
+                    total += atoms
+                    nextVal *= 2
+                return utxos, True
+
+            poolPriv = Curve.generateKey()
+            pkHash = crypto.hash160(poolPriv.pub.serializeCompressed().b)
+            poolAddr = crypto.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
+            scriptHash = crypto.hash160("some script. doesn't matter".encode())
+            scriptAddr = crypto.AddressScriptHash(testnet.ScriptHashAddrID, scriptHash)
+            ticketPrice = blockchain.stakeDiff()
+
+            request = account.TicketRequest(
+                minConf=0,
+                expiry=0,
+                spendLimit=ticketPrice * 2 * 1.1,
+                poolAddress=poolAddr.string(),
+                votingAddress=scriptAddr.string(),
+                ticketFee=0,
+                poolFees=7.5,
+                count=2,
+                txFee=0,
+            )
+
+            ticket, spent, newUTXOs = blockchain.purchaseTickets(
+                KeySource(), utxosource, request
+            )
+        finally:
+            blockchain.close()
+
+    def test_revoke_ticket(self, tmpdir):
+        blockchain = dcrdata.DcrdataBlockchain(
+            tmpdir.join("db.db"), testnet, "https://testnet.dcrdata.org"
+        )
+        blockchain.connect()
+
+        def broadcast(txHex):
+            print("test skipping broadcast of transaction: %s" % txHex)
+            return True
+
+        blockchain.broadcast = broadcast
+
+        class test:
+            def __init__(
+                self, ticket="", privKey="", redeemScript="", revocation="",
+            ):
+                self.ticket = ticket
+                self.privKey = privKey
+                self.redeemScript = redeemScript
+                self.revocation = revocation
+
+        tests = [
+            test(
+                "010000000210fd1f5623e2469d9bb390ad21b12f6710f5d6be0e130df074cf"
+                "d8614d0c4e050400000000ffffffff10fd1f5623e2469d9bb390ad21b12f67"
+                "10f5d6be0e130df074cfd8614d0c4e050500000000ffffffff05508f4a7401"
+                "000000000018baa91438a8a93737e62e806f49d1465518a02f110d57fe8700"
+                "000000000000000000206a1e1aee120db13f4e4f785aec3da97b48963de58e"
+                "bd37570200000000000058000000000000000000001abd76a9140000000000"
+                "00000000000000000000000000000088ac00000000000000000000206a1eab"
+                "c7372997a530b43e8e17a4850602b28e0768dd454d48740100000000580000"
+                "00000000000000001abd76a914000000000000000000000000000000000000"
+                "000088ac000000000000000002375702000000000000000000000000006a47"
+                "304402202b5f4a97abf78d95875de75b244f9b4c7f60bb40b01a9188133102"
+                "2a03a3bf32022047f951e0414e4f28518b5254974abeb93f77727bee7c6fbd"
+                "5010f8bf375dd10f012102ec908402cb3ab128a9a68978fbb3b33f1c97d715"
+                "afb8f76dbbe300619878f095454d48740100000000000000000000006a4730"
+                "4402200435095049ac7b3f3c47a43d92afc22db032b929357f2f216eb24e91"
+                "cd0d2d2802203ca93654cc1f193f11ce0c7e74f9959edd984c15d54f99b0d2"
+                "27b1cdd99a4a3e012102ec908402cb3ab128a9a68978fbb3b33f1c97d715af"
+                "b8f76dbbe300619878f095",
+                #
+                "d407f81cb789e65579590d5e50027431f1fdea21c2ebef12944b7842e71eaf",
+                #
+                "51210289a43bf822daf338bb07555476a967cc46545a58c513a0badc99861c"
+                "81f985782103b1f62148c92802a47ce98a49d1f14f397adc759131f6f6a5c8"
+                "8ad9dfedd53f9b52ae",
+                #
+                "0100000001113d36ae0156c1f5a3071de1f7f10e9e4521a77266b1927f832b"
+                "abb9fe3d5cd90000000001ffffffff022c4d02000000000000001abc76a914"
+                "1aee120db13f4e4f785aec3da97b48963de58ebd88ac193848740100000000"
+                "001abc76a914abc7372997a530b43e8e17a4850602b28e0768dd88ac000000"
+                "000000000001508f4a740100000000000000000000009148304502210099b8"
+                "e13022e13d19229fff3a2b08ebf54f5cd4ea79c85618d04a57a735283e9102"
+                "203e0fd5a66a168edff1bbcaeaa9d5b2d5e224cbd5d90a6c0099c73810d749"
+                "3924014751210289a43bf822daf338bb07555476a967cc46545a58c513a0ba"
+                "dc99861c81f985782103b1f62148c92802a47ce98a49d1f14f397adc759131"
+                "f6f6a5c88ad9dfedd53f9b52ae",
+            ),
+            test(
+                "010000000228a301cae233e252143e6fff3ccd348e156bbcc8ea158cfb4a1f"
+                "e19f78cad1e80a00000000ffffffff28a301cae233e252143e6fff3ccd348e"
+                "156bbcc8ea158cfb4a1fe19f78cad1e80b00000000ffffffff05d00fb2fb00"
+                "000000000018baa91438a8a93737e62e806f49d1465518a02f110d57fe8700"
+                "000000000000000000206a1e1aee120db13f4e4f785aec3da97b48963de58e"
+                "bdcf550200000000000058000000000000000000001abd76a9140000000000"
+                "00000000000000000000000000000088ac00000000000000000000206a1e94"
+                "9293b5f8acd5a0a871ce417cd5354d9715a2912dcfaffb0000000000580000"
+                "00000000000000001abd76a914000000000000000000000000000000000000"
+                "000088ac000000000000000002cf5502000000000000000000000000006b48"
+                "3045022100a4072a6a09058cf1b2713b75e636bcdf418c9897aa18cd584cfc"
+                "f0229bf6b7d102200cb94cfef85a31943ab1e0daba90578c3b465be26e4a94"
+                "a19e1da5ec70586193012103ac3936e6c8d0fd9cefde6cc9552289c943a1eb"
+                "4abe1601de8f8e46b8f7ed508d2dcfaffb0000000000000000000000006a47"
+                "304402202fc0578332b69746109066cc7d7cb9b86f0a693639bbe4dc84c83f"
+                "26ef0e3bad022010ad57133bcc77bb36600488679f5da6ab6740b4d743470b"
+                "cd60f2ecda70aa7f012103ac3936e6c8d0fd9cefde6cc9552289c943a1eb4a"
+                "be1601de8f8e46b8f7ed508d",
+                #
+                "d407f81cb789e65579590d5e50027431f1fdea21c2ebef12944b7842e71eaf",
+                #
+                "51210289a43bf822daf338bb07555476a967cc46545a58c513a0badc99861c"
+                "81f985782103b1f62148c92802a47ce98a49d1f14f397adc759131f6f6a5c8"
+                "8ad9dfedd53f9b52ae",
+                #
+                "0100000001d033e1ddf9c44a1402d8dc8d6cfcee634a459537a078359a3c51"
+                "153b7ba67b220000000001ffffffff02c44b02000000000000001abc76a914"
+                "1aee120db13f4e4f785aec3da97b48963de58ebd88ac01baaffb0000000000"
+                "001abc76a914949293b5f8acd5a0a871ce417cd5354d9715a29188ac000000"
+                "000000000001d00fb2fb00000000000000000000000091483045022100f83a"
+                "a623b21d302cdc65b6b227fe53f3796379031dd1fee9bc398680f846221d02"
+                "2062282396b391ba38612afea9a648b7db7ef54b0d4b06bddae7783bb25cf6"
+                "ba1f014751210289a43bf822daf338bb07555476a967cc46545a58c513a0ba"
+                "dc99861c81f985782103b1f62148c92802a47ce98a49d1f14f397adc759131"
+                "f6f6a5c88ad9dfedd53f9b52ae",
+            ),
+        ]
+
+        for test in tests:
+            ticket = msgtx.MsgTx.deserialize(ByteArray(test.ticket))
+            keysource = account.KeySource(
+                priv=lambda _: crypto.privKeyFromBytes(ByteArray(test.privKey)),
+                internal=lambda: "",
+            )
+            redeemScript = ByteArray(test.redeemScript)
+            revocation = blockchain.revokeTicket(ticket, keysource, redeemScript)
+            assert test.revocation == revocation.txHex()

--- a/decred/tests/unit/dcr/test_account.py
+++ b/decred/tests/unit/dcr/test_account.py
@@ -1,10 +1,9 @@
 """
-Copyright (c) 2019, the Decred developers
+Copyright (c) 2019-2020, the Decred developers
 See LICENSE for details
 """
 
 import json
-import os
 
 from decred.crypto import crypto, opcode, rando
 from decred.dcr import account, nets, txscript
@@ -229,11 +228,11 @@ dcrdataUTXOs = json.loads(
 utxoTotal = 942168886 + 942093929
 
 
-def test_account(tmp_path):
+def test_account(tmpdir):
     """
     Test account functionality.
     """
-    db = KeyValueDatabase(os.path.join(tmp_path, "tmp.db")).child("tmp")
+    db = KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
     acct = newAccount(db)
     for n in range(20):
         acct.nextExternalAddress()
@@ -468,8 +467,8 @@ def test_balance(prepareLogger):
     assert bal.staked == reBal.staked
 
 
-def test_gap_handling(tmp_path):
-    db = KeyValueDatabase(os.path.join(tmp_path, "tmp.db")).child("tmp")
+def test_gap_handling(tmpdir):
+    db = KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
     internalAddrs = [
         "DskHpgbEb6hqkuHchHhtyojpehFToEtjQSo",
         "Dsm4oCLnLraGDedfU5unareezTNT75kPbRb",
@@ -720,7 +719,7 @@ def test_ticket_info_from_spending_tx():
     assert tinfo.spendTxFee == 1
 
 
-def test_account_update_spent_tickets(tmp_path):
+def test_account_update_spent_tickets(tmpdir):
     """
     Test updating spent tickets.
     """
@@ -741,7 +740,7 @@ def test_account_update_spent_tickets(tmp_path):
             self.utxos = {}
             self.net = nets.testnet
 
-    db = KeyValueDatabase(os.path.join(tmp_path, "tmp.db")).child("tmp")
+    db = KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
 
     acct = FakeAccount()
     tDB = acct.ticketDB = db.child(
@@ -899,7 +898,7 @@ def test_account_update_spent_tickets(tmp_path):
     assert txid not in tDB
 
 
-def test_account_calc_ticket_profits(tmp_path):
+def test_account_calc_ticket_profits(tmpdir):
     """
     Test ticket profit calculation.
     """
@@ -908,7 +907,7 @@ def test_account_calc_ticket_profits(tmp_path):
         def __init__(self):
             pass
 
-    db = KeyValueDatabase(os.path.join(tmp_path, "tmp.db")).child("tmp")
+    db = KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
 
     acct = FakeAccount()
     tDB = acct.ticketDB = db.child(
@@ -957,7 +956,7 @@ def test_account_calc_ticket_profits(tmp_path):
     assert txFees == t
 
 
-def test_account_spend_ticket(tmp_path):
+def test_account_spend_ticket(tmpdir):
     """
     Test updating spent tickets.
     """
@@ -1010,7 +1009,7 @@ def test_account_spend_ticket(tmp_path):
             self.blockchain = Dummy()
             self.net = nets.testnet
 
-    db = KeyValueDatabase(os.path.join(tmp_path, "tmp.db")).child("tmp")
+    db = KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
 
     acct = FakeAccount()
     tDB = acct.ticketDB = db.child(

--- a/decred/tests/unit/dcr/test_account.py
+++ b/decred/tests/unit/dcr/test_account.py
@@ -228,11 +228,11 @@ dcrdataUTXOs = json.loads(
 utxoTotal = 942168886 + 942093929
 
 
-def test_account(tmpdir):
+def test_account():
     """
     Test account functionality.
     """
-    db = KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
+    db = KeyValueDatabase(":memory:").child("tmp")
     acct = newAccount(db)
     for n in range(20):
         acct.nextExternalAddress()
@@ -467,8 +467,8 @@ def test_balance(prepareLogger):
     assert bal.staked == reBal.staked
 
 
-def test_gap_handling(tmpdir):
-    db = KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
+def test_gap_handling():
+    db = KeyValueDatabase(":memory:").child("tmp")
     internalAddrs = [
         "DskHpgbEb6hqkuHchHhtyojpehFToEtjQSo",
         "Dsm4oCLnLraGDedfU5unareezTNT75kPbRb",
@@ -719,7 +719,7 @@ def test_ticket_info_from_spending_tx():
     assert tinfo.spendTxFee == 1
 
 
-def test_account_update_spent_tickets(tmpdir):
+def test_account_update_spent_tickets():
     """
     Test updating spent tickets.
     """
@@ -740,7 +740,7 @@ def test_account_update_spent_tickets(tmpdir):
             self.utxos = {}
             self.net = nets.testnet
 
-    db = KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
+    db = KeyValueDatabase(":memory:").child("tmp")
 
     acct = FakeAccount()
     tDB = acct.ticketDB = db.child(
@@ -898,7 +898,7 @@ def test_account_update_spent_tickets(tmpdir):
     assert txid not in tDB
 
 
-def test_account_calc_ticket_profits(tmpdir):
+def test_account_calc_ticket_profits():
     """
     Test ticket profit calculation.
     """
@@ -907,7 +907,7 @@ def test_account_calc_ticket_profits(tmpdir):
         def __init__(self):
             pass
 
-    db = KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
+    db = KeyValueDatabase(":memory:").child("tmp")
 
     acct = FakeAccount()
     tDB = acct.ticketDB = db.child(
@@ -956,7 +956,7 @@ def test_account_calc_ticket_profits(tmpdir):
     assert txFees == t
 
 
-def test_account_spend_ticket(tmpdir):
+def test_account_spend_ticket():
     """
     Test updating spent tickets.
     """
@@ -1009,7 +1009,7 @@ def test_account_spend_ticket(tmpdir):
             self.blockchain = Dummy()
             self.net = nets.testnet
 
-    db = KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
+    db = KeyValueDatabase(":memory:").child("tmp")
 
     acct = FakeAccount()
     tDB = acct.ticketDB = db.child(

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -321,10 +321,10 @@ class TestDcrdataBlockchain:
         revocation=None,
     )
 
-    def test_misc(self, http_get_post, tmpdir):
+    def test_misc(self, http_get_post):
         preload_api_list(http_get_post)
         http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
-        ddb = DcrdataBlockchain(tmpdir.join("test.db"), testnet, BASE_URL)
+        ddb = DcrdataBlockchain(":memory:", testnet, BASE_URL)
         assert ddb.tipHeight == 1
 
         # getAgendasInfo
@@ -340,16 +340,16 @@ class TestDcrdataBlockchain:
         http_get_post(f"{BASE_URL}api/stake/diff", {"estimates": {"expected": 1}})
         assert ddb.nextStakeDiff() == 1e8
 
-    def test_subscriptions(self, http_get_post, tmpdir):
+    def test_subscriptions(self, http_get_post):
         # Exception in updateTip.
         preload_api_list(http_get_post)
         with pytest.raises(DecredError):
-            DcrdataBlockchain(tmpdir.join("test.db"), testnet, BASE_URL)
+            DcrdataBlockchain(":memory:", testnet, BASE_URL)
 
         # Successful creation.
         preload_api_list(http_get_post)
         http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
-        ddb = DcrdataBlockchain(tmpdir.join("test.db"), testnet, BASE_URL)
+        ddb = DcrdataBlockchain(":memory:", testnet, BASE_URL)
 
         # Set the mock WebsocketClient.
         ddb.dcrdata.ps = MockWebSocketClient()
@@ -394,10 +394,10 @@ class TestDcrdataBlockchain:
         ddb.pubsubSignal(sig)
         assert block_queue[0] == sig
 
-    def test_utxos(self, http_get_post, tmpdir):
+    def test_utxos(self, http_get_post):
         preload_api_list(http_get_post)
         http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
-        ddb = DcrdataBlockchain(tmpdir.join("test.db"), testnet, BASE_URL)
+        ddb = DcrdataBlockchain(":memory:", testnet, BASE_URL)
 
         # txVout error
         with pytest.raises(DecredError):
@@ -467,10 +467,10 @@ class TestDcrdataBlockchain:
         http_get_post(headerURL, self.blockHeader)
         assert ddb.confirmUTXO(utxo) is True
 
-    def test_blocks(self, http_get_post, tmpdir):
+    def test_blocks(self, http_get_post):
         preload_api_list(http_get_post)
         http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
-        ddb = DcrdataBlockchain(tmpdir.join("test.db"), testnet, BASE_URL)
+        ddb = DcrdataBlockchain(":memory:", testnet, BASE_URL)
 
         # blockHeader
         with pytest.raises(DecredError):
@@ -513,10 +513,10 @@ class TestDcrdataBlockchain:
             ByteArray(self.blockHash)
         )
 
-    def test_for_tx(self, http_get_post, tmpdir):
+    def test_for_tx(self, http_get_post):
         preload_api_list(http_get_post)
         http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
-        ddb = DcrdataBlockchain(tmpdir.join("test.db"), testnet, BASE_URL)
+        ddb = DcrdataBlockchain(":memory:", testnet, BASE_URL)
 
         # tinyBlockForTx
         # Preload the broken decoded tx.

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -321,10 +321,10 @@ class TestDcrdataBlockchain:
         revocation=None,
     )
 
-    def test_misc(self, http_get_post, tmp_path):
+    def test_misc(self, http_get_post, tmpdir):
         preload_api_list(http_get_post)
         http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
-        ddb = DcrdataBlockchain(str(tmp_path / "test.db"), testnet, BASE_URL)
+        ddb = DcrdataBlockchain(tmpdir.join("test.db"), testnet, BASE_URL)
         assert ddb.tipHeight == 1
 
         # getAgendasInfo
@@ -340,16 +340,16 @@ class TestDcrdataBlockchain:
         http_get_post(f"{BASE_URL}api/stake/diff", {"estimates": {"expected": 1}})
         assert ddb.nextStakeDiff() == 1e8
 
-    def test_subscriptions(self, http_get_post, tmp_path):
+    def test_subscriptions(self, http_get_post, tmpdir):
         # Exception in updateTip.
         preload_api_list(http_get_post)
         with pytest.raises(DecredError):
-            DcrdataBlockchain(str(tmp_path / "test.db"), testnet, BASE_URL)
+            DcrdataBlockchain(tmpdir.join("test.db"), testnet, BASE_URL)
 
         # Successful creation.
         preload_api_list(http_get_post)
         http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
-        ddb = DcrdataBlockchain(str(tmp_path / "test.db"), testnet, BASE_URL)
+        ddb = DcrdataBlockchain(tmpdir.join("test.db"), testnet, BASE_URL)
 
         # Set the mock WebsocketClient.
         ddb.dcrdata.ps = MockWebSocketClient()
@@ -394,10 +394,10 @@ class TestDcrdataBlockchain:
         ddb.pubsubSignal(sig)
         assert block_queue[0] == sig
 
-    def test_utxos(self, http_get_post, tmp_path):
+    def test_utxos(self, http_get_post, tmpdir):
         preload_api_list(http_get_post)
         http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
-        ddb = DcrdataBlockchain(str(tmp_path / "test.db"), testnet, BASE_URL)
+        ddb = DcrdataBlockchain(tmpdir.join("test.db"), testnet, BASE_URL)
 
         # txVout error
         with pytest.raises(DecredError):
@@ -467,10 +467,10 @@ class TestDcrdataBlockchain:
         http_get_post(headerURL, self.blockHeader)
         assert ddb.confirmUTXO(utxo) is True
 
-    def test_blocks(self, http_get_post, tmp_path):
+    def test_blocks(self, http_get_post, tmpdir):
         preload_api_list(http_get_post)
         http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
-        ddb = DcrdataBlockchain(str(tmp_path / "test.db"), testnet, BASE_URL)
+        ddb = DcrdataBlockchain(tmpdir.join("test.db"), testnet, BASE_URL)
 
         # blockHeader
         with pytest.raises(DecredError):
@@ -513,10 +513,10 @@ class TestDcrdataBlockchain:
             ByteArray(self.blockHash)
         )
 
-    def test_for_tx(self, http_get_post, tmp_path):
+    def test_for_tx(self, http_get_post, tmpdir):
         preload_api_list(http_get_post)
         http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
-        ddb = DcrdataBlockchain(str(tmp_path / "test.db"), testnet, BASE_URL)
+        ddb = DcrdataBlockchain(tmpdir.join("test.db"), testnet, BASE_URL)
 
         # tinyBlockForTx
         # Preload the broken decoded tx.

--- a/decred/tests/unit/util/test_database.py
+++ b/decred/tests/unit/util/test_database.py
@@ -32,9 +32,9 @@ class TBlobber:
         return self.b == other.b
 
 
-def test_database(prepareLogger, randBytes, tmpdir):
+def test_database(prepareLogger, randBytes):
     # Open a key value db in the temp directory.
-    master = database.KeyValueDatabase(tmpdir.join("tmp.sqlite"))
+    master = database.KeyValueDatabase(":memory:")
 
     # '$' in bucket name is illegal.
     with pytest.raises(DecredError):

--- a/decred/tests/unit/wallet/test_accounts.py
+++ b/decred/tests/unit/wallet/test_accounts.py
@@ -37,12 +37,12 @@ def test_child_neuter(prepareLogger):
     assert pub.string() == expStr
 
 
-def test_change_addresses(prepareLogger, tmpdir):
+def test_change_addresses(prepareLogger):
     """
     Test internal branch address derivation.
     """
     cryptoKey = encode.ByteArray(rando.generateSeed(32))
-    db = database.KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
+    db = database.KeyValueDatabase(":memory:").child("tmp")
     # ticker for coin type is ok. Case insensitive.
     am = accounts.createNewAccountManager(tRoot, cryptoKey, "DcR", nets.mainnet, db)
     acct = am.openAccount(0, cryptoKey)
@@ -50,9 +50,9 @@ def test_change_addresses(prepareLogger, tmpdir):
         acct.nextInternalAddress()
 
 
-def test_account_manager(prepareLogger, tmpdir):
+def test_account_manager(prepareLogger):
     cryptoKey = encode.ByteArray(rando.generateSeed(32))
-    db = database.KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
+    db = database.KeyValueDatabase(":memory:").child("tmp")
     # 42 = Decred
     am = accounts.createNewAccountManager(tRoot, cryptoKey, 42, nets.mainnet, db)
 

--- a/decred/tests/unit/wallet/test_accounts.py
+++ b/decred/tests/unit/wallet/test_accounts.py
@@ -3,9 +3,6 @@ Copyright (c) 2019-2020, the Decred developers
 See LICENSE for details
 """
 
-import os
-from tempfile import TemporaryDirectory
-
 import pytest
 
 from decred import DecredError
@@ -40,50 +37,48 @@ def test_child_neuter(prepareLogger):
     assert pub.string() == expStr
 
 
-def test_change_addresses(prepareLogger):
+def test_change_addresses(prepareLogger, tmpdir):
     """
     Test internal branch address derivation.
     """
     cryptoKey = encode.ByteArray(rando.generateSeed(32))
-    with TemporaryDirectory() as tempDir:
-        db = database.KeyValueDatabase(os.path.join(tempDir, "tmp.db")).child("tmp")
-        # ticker for coin type is ok. Case insensitive.
-        am = accounts.createNewAccountManager(tRoot, cryptoKey, "DcR", nets.mainnet, db)
-        acct = am.openAccount(0, cryptoKey)
-        for i in range(10):
-            acct.nextInternalAddress()
+    db = database.KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
+    # ticker for coin type is ok. Case insensitive.
+    am = accounts.createNewAccountManager(tRoot, cryptoKey, "DcR", nets.mainnet, db)
+    acct = am.openAccount(0, cryptoKey)
+    for i in range(10):
+        acct.nextInternalAddress()
 
 
-def test_account_manager(prepareLogger):
+def test_account_manager(prepareLogger, tmpdir):
     cryptoKey = encode.ByteArray(rando.generateSeed(32))
-    with TemporaryDirectory() as tempDir:
-        db = database.KeyValueDatabase(os.path.join(tempDir, "tmp.db")).child("tmp")
-        # 42 = Decred
-        am = accounts.createNewAccountManager(tRoot, cryptoKey, 42, nets.mainnet, db)
+    db = database.KeyValueDatabase(tmpdir.join("tmp.db")).child("tmp")
+    # 42 = Decred
+    am = accounts.createNewAccountManager(tRoot, cryptoKey, 42, nets.mainnet, db)
 
-        acct = am.openAccount(0, cryptoKey)
-        tempAcct = am.addAccount(cryptoKey, "temp")
-        assert am.account(1) == tempAcct
-        assert am.listAccounts() == [acct, tempAcct]
-        am.accounts[3] = tempAcct
-        del am.accounts[1]
-        with pytest.raises(AssertionError):
-            am.listAccounts()
-        del am.accounts[3]
+    acct = am.openAccount(0, cryptoKey)
+    tempAcct = am.addAccount(cryptoKey, "temp")
+    assert am.account(1) == tempAcct
+    assert am.listAccounts() == [acct, tempAcct]
+    am.accounts[3] = tempAcct
+    del am.accounts[1]
+    with pytest.raises(AssertionError):
+        am.listAccounts()
+    del am.accounts[3]
 
-        with pytest.raises(DecredError):
-            accounts.AccountManager.unblob(encode.BuildyBytes(0))
+    with pytest.raises(DecredError):
+        accounts.AccountManager.unblob(encode.BuildyBytes(0))
 
-        zeroth = acct.currentAddress()
-        b = am.serialize()
-        reAM = accounts.AccountManager.unblob(b.b)
+    zeroth = acct.currentAddress()
+    b = am.serialize()
+    reAM = accounts.AccountManager.unblob(b.b)
 
-        assert am.coinType == reAM.coinType
-        assert am.netName == reAM.netName
-        assert am.netName == reAM.netName
+    assert am.coinType == reAM.coinType
+    assert am.netName == reAM.netName
+    assert am.netName == reAM.netName
 
-        reAM.load(db, None)
-        reAcct = reAM.openAccount(0, cryptoKey)
-        reZeroth = reAcct.currentAddress()
+    reAM.load(db, None)
+    reAcct = reAM.openAccount(0, cryptoKey)
+    reZeroth = reAcct.currentAddress()
 
-        assert zeroth == reZeroth
+    assert zeroth == reZeroth


### PR DESCRIPTION
Use in-memory sqlite3 databases in all tests instead of `TemporaryDirectory` from stdlib or the `tmp_path` pytest fixture.

Also convert `tests/integration/dcr/test_dcrdata.py` to the pytest format.

The diff is somewhat messed up by the large de-indented blocks, unfortunately.

NOTE: originally I converted the tests to use the pytest's `tmpdir` feature, but then realized that using in-memory databases would be simpler and make tests faster.