### PR TITLE
tests: increase coverage of dcr/account.py

### DIFF
--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -417,10 +417,10 @@ class TicketInfo:
             lotteryBlock=lotteryBlock,
             vote=spendingTx.txid() if isVote else None,
             revocation=spendingTx.txid() if not isVote else None,
-            stakebase=stakebase if isVote else 0,
+            poolFee=poolFee,
             purchaseTxFee=purchaseTxFee,
             spendTxFee=spendTxFee,
-            poolFee=poolFee,
+            stakebase=stakebase if isVote else 0,
         )
 
     def serialize(self):
@@ -476,11 +476,11 @@ class UTXO:
         self.scriptPubKey = scriptPubKey
         self.height = height
         self.satoshis = satoshis
-        self.amount = round(satoshis / 1e8, 8)
         self.maturity = maturity
+        self.tinfo = tinfo
+        self.amount = round(satoshis / 1e8, 8)
         self.scriptClass = None
         self.parseScriptClass()
-        self.tinfo = tinfo
 
     @staticmethod
     def blob(utxo):
@@ -516,9 +516,9 @@ class UTXO:
         tinfo = TicketInfo.unblob(tinfoB) if tinfoB else None
 
         utxo = UTXO(
-            d[0].decode("utf-8"),
-            ByteArray(d[1]),
-            encode.intFromBytes(d[2]),
+            address=d[0].decode("utf-8"),
+            txHash=ByteArray(d[1]),
+            vout=encode.intFromBytes(d[2]),
             ts=ts,
             scriptPubKey=f(d[4]),
             height=iFunc(d[5], signed=True),
@@ -1715,7 +1715,7 @@ class Account:
             pool (vsp.VotingServiceProvider): The stake pool object.
         """
         if not isinstance(pool, VotingServiceProvider):
-            raise AssertionError("setPool given wrong type %s" % type(pool))
+            raise DecredError("setPool given wrong type %s" % type(pool))
         self.stakePools = [pool] + [
             p for p in self.stakePools if p.apiKey != pool.apiKey
         ]
@@ -2009,5 +2009,5 @@ def readAddrs(db):
     """
     pairs = sorted(db.items(), key=lambda pair: pair[0])
     if pairs and len(pairs) != pairs[-1][0] + 1:
-        raise AssertionError("address index mismatch")
+        raise DecredError("address index mismatch")
     return [pair[1] for pair in pairs]

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -564,7 +564,7 @@ class DcrdataBlockchain:
         try:
             tinfo = account.TicketInfo.parse(self.dcrdata.tx.tinfo(txid))
         except Exception:
-            tinfo = account.TicketInfo("mempool", None, 0, 0, None, None, None)
+            tinfo = account.TicketInfo("mempool", None, 0, 0)
 
         return tinfo
 


### PR DESCRIPTION
Increase test coverage of `dcr/account.py`, first round. Part of #70.