### PR TITLE
vsp: Add per ticket authentication

### DIFF
--- a/tinywallet/tinywallet/screens.py
+++ b/tinywallet/tinywallet/screens.py
@@ -2173,7 +2173,7 @@ class AgendasScreen(Screen):
             def changeVote():
                 app.emitSignal(ui.WORKING_SIGNAL)
                 try:
-                    pools[0].setVoteBits(voteBits)
+                    pools[0].setVoteBitsV3(voteBits, acct)
                     app.appWindow.showSuccess("vote choices updated")
                     dropdown.lastIndex = idx
                 except Exception as e:


### PR DESCRIPTION
closes #17 

Add ability to change vote preverences using a new authorization scheme.
A timestamp signed with a tickets's user commitment address's private key
is used to prove ownership of a ticket. This data is sent using a
different header and comma separated values.