### PR TITLE
accounts: add account discovery

### DIFF
--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -896,6 +896,28 @@ class Account:
         acct.gapLimit = iFunc(d[6])
         return acct
 
+    @staticmethod
+    def txsExistForKey(pubX, blockchain):
+        """
+        Returns True if any transactions are found within the default gap limit.
+
+        Args:
+            blockchain (Blockchain): A Blockchain.
+            pubX (crypto.ExtendedKey): An extended public account key.
+            netParams (module): The network parameters.
+        """
+        extPub = pubX.child(EXTERNAL_BRANCH)
+        intPub = pubX.child(INTERNAL_BRANCH)
+        addrs = [
+            extPub.deriveChildAddress(idx, blockchain.params)
+            for idx in range(DefaultGapLimit)
+        ]
+        addrs += [
+            intPub.deriveChildAddress(idx, blockchain.params)
+            for idx in range(DefaultGapLimit)
+        ]
+        return blockchain.addrsHaveTxs(addrs)
+
     def serialize(self):
         """
         Serialize the Account.
@@ -1746,7 +1768,7 @@ class Account:
         bc = self.blockchain
         addr = pool.purchaseInfo.ticketAddress
         checkTxids = []
-        for txid in bc.txsForAddr(addr):
+        for txid in bc.txidsForAddr(addr):
             self.addTxid(addr, txid)
             checkTxids.append(txid)
         for utxo in bc.UTXOs([addr]):
@@ -1968,7 +1990,7 @@ class Account:
 
         while addrs:
             for addr in addrs:
-                for txid in blockchain.txsForAddr(addr):
+                for txid in blockchain.txidsForAddr(addr):
                     requestedTxs += 1
                     self.addTxid(addr, txid)
             addrs = self.generateGapAddresses()

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -33,6 +33,11 @@ POST_HEADERS = {
 }
 WS_DONE = object()
 
+# These two come from dcrdata, and are potentially subject to change, though
+# unlikely.
+MaxInsightAddrsTxns = 250
+AddrsPerRequest = 25
+
 
 class DcrdataError(DecredError):
     pass
@@ -110,7 +115,8 @@ InsightPaths = [
     "/tx/send",
     "/insight/api/addr/{address}/utxo",
     "/insight/api/addr/{address}",
-    "insight/api/tx/send",
+    "/insight/api/tx/send",
+    "/insight/api/addrs/{addresses}/txs",
 ]
 
 
@@ -507,17 +513,16 @@ class DcrdataBlockchain:
         """
         utxos = []
         addrCount = len(addrs)
-        addrsPerRequest = 20  # dcrdata allows 25
         get = lambda addrs: self.dcrdata.insight.api.addr.utxo(",".join(addrs))
-        for i in range(addrCount // addrsPerRequest + 1):
-            start = i * addrsPerRequest
-            end = start + addrsPerRequest
+        for i in range(addrCount // AddrsPerRequest + 1):
+            start = i * AddrsPerRequest
+            end = start + AddrsPerRequest
             if start < addrCount:
                 ads = addrs[start:end]
                 utxos += [self.processNewUTXO(u) for u in get(ads)]
         return utxos
 
-    def txsForAddr(self, addr):
+    def txidsForAddr(self, addr):
         """
         Get the transaction IDs for the provided address.
 
@@ -528,6 +533,31 @@ class DcrdataBlockchain:
         if "transactions" not in addrInfo:
             return []
         return addrInfo["transactions"]
+
+    def addrsHaveTxs(self, addrs):
+        """
+        Return True if there are any transactions for the list of addresses.
+        Used as part of the account discovery process.
+
+        Args:
+            addrs list(string): The list of addresses to check.
+        """
+
+        def gettxs(addrs):
+            # 'from' is reserved, so I'll pass it like this.
+            return self.dcrdata.insight.api.addrs.txs(
+                ",".join(addrs), **{"from": 0, "to": 1}
+            ).get("items")
+
+        addrCount = len(addrs)
+        for i in range(addrCount // AddrsPerRequest + 1):
+            start = i * AddrsPerRequest
+            end = start + AddrsPerRequest
+            if start < addrCount:
+                ads = addrs[start:end]
+                if gettxs(ads):
+                    return True
+        return False
 
     def txVout(self, txid, vout):
         """

--- a/decred/decred/wallet/accounts.py
+++ b/decred/decred/wallet/accounts.py
@@ -14,10 +14,11 @@ from decred.util import chains, encode, helpers
 
 EXTERNAL_BRANCH = 0
 INTERNAL_BRANCH = 1
+ACCOUNT_GAP_LIMIT = 10
 
 DEFAULT_ACCOUNT_NAME = "default"
 
-log = helpers.getLogger("TCRYP")
+log = helpers.getLogger("ACCTS")
 
 
 def checkBranchKeys(acctKey):
@@ -240,6 +241,33 @@ class AccountManager:
         acct = self.accounts[idx]
         acct.unlock(cryptoKey)
         return acct
+
+    def discover(self, cryptoKey):
+        """
+        Discover accounts up to the account gap limit. If an account is
+        discovered, all accounts up to and including the discovered account's
+        index will be created.
+
+        Args:
+            cryptoKey (ByteArray): The master encoding key.
+        """
+        coinExtKey = self.coinKey(cryptoKey)
+        blockchain = chains.chain(self.coinType)
+        lastSeenIdx = len(self.acctDB) - 1
+        idx = lastSeenIdx + 1
+        acctConstructor = chains.AccountConstructors[self.coinType]
+        while True:
+            acctKeyPriv = coinExtKey.deriveAccountKey(idx)
+            acctKeyPub = acctKeyPriv.neuter()
+            if acctConstructor.txsExistForKey(acctKeyPub, blockchain):
+                # Add accounts up to the newly seen index.
+                log.info(f"account discovered at index {idx}")
+                while len(self.accounts) <= idx:
+                    self.addAccount(cryptoKey, f"Account {len(self.accounts)}")
+                lastSeenIdx = idx
+            idx += 1
+            if idx - lastSeenIdx > ACCOUNT_GAP_LIMIT:
+                break
 
 
 def createNewAccountManager(root, cryptoKey, coinType, netParams, db):

--- a/decred/tests/unit/dcr/test_account.py
+++ b/decred/tests/unit/dcr/test_account.py
@@ -20,6 +20,10 @@ LOGGER_ID = "test_account"
 
 ticketScript = ByteArray("baa914f5618dfc002becfe840da65f6a49457f41d4f21787")
 
+testSeed = ByteArray(
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+).b
+
 dcrdataTinfo = json.loads(
     """
 {
@@ -437,9 +441,6 @@ class TestAccount:
 
     def newAccount(self, db, blockchain=None):
         # Create an account key
-        testSeed = ByteArray(
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-        ).b
         xk = crypto.ExtendedKey.new(testSeed)
         dcrKey = xk.deriveCoinTypeKey(nets.mainnet)
         acctKey = dcrKey.deriveAccountKey(0)
@@ -508,7 +509,7 @@ class TestAccount:
 
         # Create a faux blockchain for the account.
         class Blockchain:
-            txsForAddr = lambda addr: []
+            txidsForAddr = lambda addr: []
             UTXOs = lambda addrs: []
             tipHeight = 5
 
@@ -641,10 +642,10 @@ class TestAccount:
         utxo = account.UTXO(addr, ByteArray(b"txid"), 0, satoshis=newVal)
 
         def t4a(*a):
-            acct.blockchain.txsForAddr = lambda *a: []
+            acct.blockchain.txidsForAddr = lambda *a: []
             return [newTx.id()]
 
-        acct.blockchain.txsForAddr = t4a
+        acct.blockchain.txidsForAddr = t4a
 
         def utxos4a(*a):
             acct.blockchain.UTXOs = lambda *a: []
@@ -1115,6 +1116,7 @@ class TestAccount:
             "DsWp4nShu8WxefgoPej1rNv4gfwy5AoULfV",
         ]
 
+        ogGapLimit = account.DefaultGapLimit
         account.DefaultGapLimit = gapLimit = 5
         acct = self.newAccount(db)
         with pytest.raises(DecredError):
@@ -1173,6 +1175,8 @@ class TestAccount:
         addrs = acct.internalAddresses
         assert addrs[len(addrs) - 1] == internalAddrs[5]
 
+        account.DefaultGapLimit = ogGapLimit
+
     def test_publicExtendedKey(self):
         db = KeyValueDatabase(":memory:").child("tmp")
         acct = self.newAccount(db)
@@ -1180,3 +1184,15 @@ class TestAccount:
             "dpubZFbjvDBkxBN5CAeqNXCkNAFizVcdMUPKJYp1vLXzkiq16yMFzREd"
             "eQ1AzaGJ7uBBhZFBruG31MGZ5SkwevLK4PiLEFSEaZm143xgvBgkWhQ"
         )
+
+    def test_txsExistForKey(self):
+        has = True
+
+        class Blockchain:
+            params = nets.mainnet
+            addrsHaveTxs = lambda a: has
+
+        xk = crypto.ExtendedKey.new(testSeed)
+        assert account.Account.txsExistForKey(xk, Blockchain)
+        has = False
+        assert not account.Account.txsExistForKey(xk, Blockchain)

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -28,7 +28,8 @@ from decred.util.encode import ByteArray
 
 
 BASE_URL = "https://example.org/"
-
+API_URL = BASE_URL + "api"
+INSIGHT_URL = BASE_URL + "insight/api"
 
 AGENDA_CHOICES_RAW = dict(
     id="choices_id",
@@ -151,7 +152,7 @@ def preload_api_list(http_get_post):
         api_list = json.loads(f.read())
 
     # Queue the list of API calls.
-    http_get_post(f"{BASE_URL}api/list", api_list)
+    http_get_post(f"{API_URL}/list", api_list)
 
 
 class TestDcrdataClient:
@@ -159,14 +160,14 @@ class TestDcrdataClient:
         preload_api_list(http_get_post)
         ddc = DcrdataClient(BASE_URL)
 
-        assert len(ddc.listEntries) == 84
+        assert len(ddc.listEntries) == 85
         assert len(ddc.subscribedAddresses) == 0
         assert ddc.endpointList()[0] == ddc.listEntries[0][1]
 
         # This prints to stdout.
         ddc.endpointGuide()
         out, err = capsys.readouterr()
-        assert len(out.splitlines()) == 84
+        assert len(out.splitlines()) == 85
 
     def test_subscriptions(self, http_get_post):
         preload_api_list(http_get_post)
@@ -323,21 +324,21 @@ class TestDcrdataBlockchain:
 
     def test_misc(self, http_get_post):
         preload_api_list(http_get_post)
-        http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
+        http_get_post(f"{API_URL}/block/best", dict(height=1))
         ddb = DcrdataBlockchain(":memory:", testnet, BASE_URL)
         assert ddb.tipHeight == 1
 
         # getAgendasInfo
-        http_get_post(f"{BASE_URL}api/stake/vote/info", AGENDAS_INFO_RAW)
+        http_get_post(f"{API_URL}/stake/vote/info", AGENDAS_INFO_RAW)
         agsinfo = ddb.getAgendasInfo()
         assert isinstance(agsinfo, agenda.AgendasInfo)
 
         # ticketPoolInfo
-        http_get_post(f"{BASE_URL}api/stake/pool", self.stakePool)
+        http_get_post(f"{API_URL}/stake/pool", self.stakePool)
         assert ddb.ticketPoolInfo().height == self.stakePool["height"]
 
         # nextStakeDiff
-        http_get_post(f"{BASE_URL}api/stake/diff", {"estimates": {"expected": 1}})
+        http_get_post(f"{API_URL}/stake/diff", {"estimates": {"expected": 1}})
         assert ddb.nextStakeDiff() == 1e8
 
     def test_subscriptions(self, http_get_post):
@@ -348,7 +349,7 @@ class TestDcrdataBlockchain:
 
         # Successful creation.
         preload_api_list(http_get_post)
-        http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
+        http_get_post(f"{API_URL}/block/best", dict(height=1))
         ddb = DcrdataBlockchain(":memory:", testnet, BASE_URL)
 
         # Set the mock WebsocketClient.
@@ -396,7 +397,7 @@ class TestDcrdataBlockchain:
 
     def test_utxos(self, http_get_post):
         preload_api_list(http_get_post)
-        http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
+        http_get_post(f"{API_URL}/block/best", dict(height=1))
         ddb = DcrdataBlockchain(":memory:", testnet, BASE_URL)
 
         # txVout error
@@ -405,9 +406,9 @@ class TestDcrdataBlockchain:
 
         # processNewUTXO
         # Preload tx and tinfo.
-        txURL = f"{BASE_URL}api/tx/hex/{self.txs[1][0]}"
+        txURL = f"{API_URL}/tx/hex/{self.txs[1][0]}"
         http_get_post(txURL, self.txs[1][1])
-        tinfoURL = f"{BASE_URL}api/tx/{self.utxos[1]['txid']}/tinfo"
+        tinfoURL = f"{API_URL}/tx/{self.utxos[1]['txid']}/tinfo"
         http_get_post(tinfoURL, self.tinfo)
         utxo = ddb.processNewUTXO(self.utxos[1])
         assert utxo.tinfo.purchaseBlock.hash == reversed(
@@ -420,7 +421,7 @@ class TestDcrdataBlockchain:
         # Precompute the UTXO data.
         addrs = [utxo["address"] for utxo in self.utxos]
         addrStr = ",".join(addrs)
-        utxoURL = f"{BASE_URL}insight/api/addr/{addrStr}/utxo"
+        utxoURL = f"{INSIGHT_URL}/addr/{addrStr}/utxo"
 
         # Preload the UTXOs but not the txs.
         http_get_post(utxoURL, self.utxos)
@@ -430,18 +431,18 @@ class TestDcrdataBlockchain:
         # Preload both the UTXOs and the txs.
         http_get_post(utxoURL, self.utxos)
         for txid, tx in self.txs:
-            txURL = f"{BASE_URL}api/tx/hex/{txid}"
+            txURL = f"{API_URL}/tx/hex/{txid}"
             http_get_post(txURL, tx)
         assert len(ddb.UTXOs(addrs)) == 3
 
-        # txsForAddr
-        txsURL = f"{BASE_URL}insight/api/addr/the_address"
+        # txidsForAddr
+        txsURL = f"{INSIGHT_URL}/addr/the_address"
         # No transactions for an address.
         http_get_post(txsURL, {})
-        assert ddb.txsForAddr("the_address") == []
+        assert ddb.txidsForAddr("the_address") == []
         # Some transactions for an address.
         http_get_post(txsURL, {"transactions": ["tx1"]})
-        assert ddb.txsForAddr("the_address") == ["tx1"]
+        assert ddb.txidsForAddr("the_address") == ["tx1"]
 
         # txVout success
         assert ddb.txVout(self.txs[2][0], 0).satoshis == 14773017964
@@ -460,16 +461,16 @@ class TestDcrdataBlockchain:
         utxo = account.UTXO.parse(self.utxos[2])
         assert ddb.confirmUTXO(utxo) is False
         # Confirmation.
-        txURL = f"{BASE_URL}api/tx/{self.txs[2][0]}"
+        txURL = f"{API_URL}/tx/{self.txs[2][0]}"
         decodedTx = {"block": {"blockhash": self.blockHash}}
         http_get_post(txURL, decodedTx)
-        headerURL = f"{BASE_URL}api/block/hash/{self.blockHash}/header/raw"
+        headerURL = f"{API_URL}/block/hash/{self.blockHash}/header/raw"
         http_get_post(headerURL, self.blockHeader)
         assert ddb.confirmUTXO(utxo) is True
 
     def test_blocks(self, http_get_post):
         preload_api_list(http_get_post)
-        http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
+        http_get_post(f"{API_URL}/block/best", dict(height=1))
         ddb = DcrdataBlockchain(":memory:", testnet, BASE_URL)
 
         # blockHeader
@@ -480,7 +481,7 @@ class TestDcrdataBlockchain:
         with pytest.raises(DecredError):
             ddb.blockHeaderByHeight(self.blockHeight).id()
         # Preload the block header.
-        headerURL = f"{BASE_URL}api/block/{self.blockHeight}/header/raw"
+        headerURL = f"{API_URL}/block/{self.blockHeight}/header/raw"
         http_get_post(headerURL, self.blockHeader)
         assert ddb.blockHeaderByHeight(self.blockHeight).id() == self.blockHash
         # Exercise the database code.
@@ -488,22 +489,22 @@ class TestDcrdataBlockchain:
 
         # blockForTx
         # Preload the first broken decoded tx.
-        txURL = f"{BASE_URL}api/tx/{self.txs[2][0]}"
+        txURL = f"{API_URL}/tx/{self.txs[2][0]}"
         decodedTx = {"block": {}}
         http_get_post(txURL, decodedTx)
         assert ddb.blockForTx(self.txs[2][0]) is None
         # Preload the second broken decoded tx.
-        txURL = f"{BASE_URL}api/tx/{self.txs[2][0]}"
+        txURL = f"{API_URL}/tx/{self.txs[2][0]}"
         decodedTx = {"block": {"blockhash": ""}}
         http_get_post(txURL, decodedTx)
         assert ddb.blockForTx(self.txs[2][0]) is None
         # Preload the right decoded tx.
-        txURL = f"{BASE_URL}api/tx/{self.txs[2][0]}"
+        txURL = f"{API_URL}/tx/{self.txs[2][0]}"
         decodedTx = {"block": {"blockhash": self.blockHash}}
         http_get_post(txURL, decodedTx)
         assert ddb.blockForTx(self.txs[2][0]).height == self.blockHeight
         # Preload the block header.
-        headerURL = f"{BASE_URL}api/block/hash/{self.blockHash}/header/raw"
+        headerURL = f"{API_URL}/block/hash/{self.blockHash}/header/raw"
         http_get_post(headerURL, self.blockHeader)
         assert ddb.blockForTx(self.txs[2][0]).hash() == reversed(
             ByteArray(self.blockHash)
@@ -515,21 +516,21 @@ class TestDcrdataBlockchain:
 
     def test_for_tx(self, http_get_post):
         preload_api_list(http_get_post)
-        http_get_post(f"{BASE_URL}api/block/best", dict(height=1))
+        http_get_post(f"{API_URL}/block/best", dict(height=1))
         ddb = DcrdataBlockchain(":memory:", testnet, BASE_URL)
 
         # tinyBlockForTx
         # Preload the broken decoded tx.
-        txURL = f"{BASE_URL}api/tx/{self.txs[2][0]}"
+        txURL = f"{API_URL}/tx/{self.txs[2][0]}"
         decodedTx = {"block": {}}
         http_get_post(txURL, decodedTx)
         assert ddb.tinyBlockForTx(self.txs[2][0]) is None
         # Preload the right decoded tx.
-        txURL = f"{BASE_URL}api/tx/{self.txs[2][0]}"
+        txURL = f"{API_URL}/tx/{self.txs[2][0]}"
         decodedTx = {"block": {"blockhash": self.blockHash}}
         http_get_post(txURL, decodedTx)
         # Preload the block header.
-        headerURL = f"{BASE_URL}api/block/hash/{self.blockHash}/header/raw"
+        headerURL = f"{API_URL}/block/hash/{self.blockHash}/header/raw"
         http_get_post(headerURL, self.blockHeader)
         assert ddb.tinyBlockForTx(self.txs[2][0]).hash == reversed(
             ByteArray(self.blockHash)
@@ -537,31 +538,31 @@ class TestDcrdataBlockchain:
 
         # ticketForTx
         # Preload the non-ticket tx.
-        txURL = f"{BASE_URL}api/tx/hex/{self.txs[2][0]}"
+        txURL = f"{API_URL}/tx/hex/{self.txs[2][0]}"
         http_get_post(txURL, self.txs[2][1])
         with pytest.raises(DecredError):
             ddb.ticketForTx(self.txs[2][0], nets.mainnet)
         # Preload the ticket decoded tx.
         blockHash = self.tinfo["purchase_block"]["hash"]
-        txURL = f"{BASE_URL}api/tx/{self.txs[1][0]}"
+        txURL = f"{API_URL}/tx/{self.txs[1][0]}"
         decodedTx = {"block": {"blockhash": blockHash}}
         http_get_post(txURL, decodedTx)
         # Preload tx and tinfo.
-        txURL = f"{BASE_URL}api/tx/hex/{self.txs[1][0]}"
+        txURL = f"{API_URL}/tx/hex/{self.txs[1][0]}"
         http_get_post(txURL, self.txs[1][1])
-        tinfoURL = f"{BASE_URL}api/tx/{self.utxos[1]['txid']}/tinfo"
+        tinfoURL = f"{API_URL}/tx/{self.utxos[1]['txid']}/tinfo"
         http_get_post(tinfoURL, self.tinfo)
         # Preload the block header.
-        headerURL = f"{BASE_URL}api/block/hash/{blockHash}/header/raw"
+        headerURL = f"{API_URL}/block/hash/{blockHash}/header/raw"
         http_get_post(headerURL, self.blockHeader)
         assert ddb.ticketForTx(self.txs[1][0], nets.mainnet).txid == self.txs[1][0]
 
         # ticketInfoForSpendingTx
         # Preload the txs.
         for txid, tx in self.txs:
-            txURL = f"{BASE_URL}api/tx/hex/{txid}"
+            txURL = f"{API_URL}/tx/hex/{txid}"
             http_get_post(txURL, tx)
-        txURL = f"{BASE_URL}api/tx/{self.txs[3][0]}"
+        txURL = f"{API_URL}/tx/{self.txs[3][0]}"
         blockHash = "00000000000000002847702f35b9227d27191d1858a7eccb94858c8f58f1066b"
         decodedTx = {"block": {"blockhash": blockHash}}
         http_get_post(txURL, decodedTx)
@@ -575,9 +576,22 @@ class TestDcrdataBlockchain:
                 "b1e0002000000000000000000000000000000000000000007000000"
             ),
         }
-        headerURL = f"{BASE_URL}api/block/hash/{blockHash}/header/raw"
+        headerURL = f"{API_URL}/block/hash/{blockHash}/header/raw"
         http_get_post(headerURL, blockHeader)
         assert (
             ddb.ticketInfoForSpendingTx(self.txs[2][0], nets.mainnet).maturityHeight
             == self.blockHeight - 1
         )
+
+    def test_addrsHaveTxs(self, http_get_post):
+        preload_api_list(http_get_post)
+        http_get_post(f"{API_URL}/block/best", dict(height=1))
+        addr = "someaddr"
+        res = dict(items=[1])
+        http_get_post(f"{INSIGHT_URL}/addrs/{addr}/txs?from=0&to=1", res)
+        ddb = DcrdataBlockchain(":memory:", testnet, BASE_URL)
+        assert ddb.addrsHaveTxs([addr])
+
+        res["items"] = []
+        http_get_post(f"{INSIGHT_URL}/addrs/{addr}/txs?from=0&to=1", res)
+        assert not ddb.addrsHaveTxs([addr])

--- a/decred/tests/unit/wallet/test_accounts.py
+++ b/decred/tests/unit/wallet/test_accounts.py
@@ -8,7 +8,7 @@ import pytest
 from decred import DecredError
 from decred.crypto import crypto, rando
 from decred.dcr import nets
-from decred.util import database, encode
+from decred.util import chains, database, encode
 from decred.wallet import accounts
 
 
@@ -44,8 +44,10 @@ def test_change_addresses(prepareLogger):
     cryptoKey = rando.newKey()
     db = database.KeyValueDatabase(":memory:").child("tmp")
     # ticker for coin type is ok. Case insensitive.
-    am = accounts.createNewAccountManager(tRoot, cryptoKey, "DcR", nets.mainnet, db)
-    acct = am.openAccount(0, cryptoKey)
+    acctMgr = accounts.createNewAccountManager(
+        tRoot, cryptoKey, "DcR", nets.mainnet, db
+    )
+    acct = acctMgr.openAccount(0, cryptoKey)
     for i in range(10):
         acct.nextInternalAddress()
 
@@ -54,31 +56,62 @@ def test_account_manager(prepareLogger):
     cryptoKey = rando.newKey()
     db = database.KeyValueDatabase(":memory:").child("tmp")
     # 42 = Decred
-    am = accounts.createNewAccountManager(tRoot, cryptoKey, 42, nets.mainnet, db)
+    acctMgr = accounts.createNewAccountManager(tRoot, cryptoKey, 42, nets.mainnet, db)
 
-    acct = am.openAccount(0, cryptoKey)
-    tempAcct = am.addAccount(cryptoKey, "temp")
-    assert am.account(1) == tempAcct
-    assert am.listAccounts() == [acct, tempAcct]
-    am.accounts[3] = tempAcct
-    del am.accounts[1]
+    acct = acctMgr.openAccount(0, cryptoKey)
+    tempAcct = acctMgr.addAccount(cryptoKey, "temp")
+    assert acctMgr.account(1) == tempAcct
+    assert acctMgr.listAccounts() == [acct, tempAcct]
+    acctMgr.accounts[3] = tempAcct
+    del acctMgr.accounts[1]
     with pytest.raises(AssertionError):
-        am.listAccounts()
-    del am.accounts[3]
+        acctMgr.listAccounts()
+    del acctMgr.accounts[3]
 
     with pytest.raises(DecredError):
         accounts.AccountManager.unblob(encode.BuildyBytes(0))
 
     zeroth = acct.currentAddress()
-    b = am.serialize()
+    b = acctMgr.serialize()
     reAM = accounts.AccountManager.unblob(b.b)
 
-    assert am.coinType == reAM.coinType
-    assert am.netName == reAM.netName
-    assert am.netName == reAM.netName
+    assert acctMgr.coinType == reAM.coinType
+    assert acctMgr.netName == reAM.netName
+    assert acctMgr.netName == reAM.netName
 
     reAM.load(db, None)
     reAcct = reAM.openAccount(0, cryptoKey)
     reZeroth = reAcct.currentAddress()
 
     assert zeroth == reZeroth
+
+
+def test_discover(prepareLogger):
+    cryptoKey = rando.newKey()
+    db = database.KeyValueDatabase(":memory:").child("tmp")
+    acctMgr = accounts.createNewAccountManager(
+        tRoot, cryptoKey, "dcr", nets.mainnet, db
+    )
+    txs = {}
+
+    class Blockchain:
+        params = nets.mainnet
+        addrsHaveTxs = lambda addrs: any(a in txs for a in addrs)
+
+    ogChain = chains.chain("dcr")
+    chains.registerChain("dcr", Blockchain)
+    ogLimit = accounts.ACCOUNT_GAP_LIMIT
+    accounts.ACCOUNT_GAP_LIMIT = 2
+
+    acctMgr.discover(cryptoKey)
+    assert len(acctMgr.accounts) == 1
+
+    coinExtKey = acctMgr.coinKey(cryptoKey)
+    acct2ExtKey = coinExtKey.deriveAccountKey(2).neuter().child(0)
+    acct2Addr5 = acct2ExtKey.deriveChildAddress(5, nets.mainnet)
+    txs[acct2Addr5] = ["tx"]
+    acctMgr.discover(cryptoKey)
+    assert len(acctMgr.accounts) == 3
+
+    chains.registerChain("dcr", ogChain)
+    accounts.ACCOUNT_GAP_LIMIT = ogLimit


### PR DESCRIPTION
Adds an account discovery method to `AccountManager` that can be used on wallets restored from seed.