### PR TITLE
multi: use "netParams" everywhere for network parameters

### DIFF
--- a/decred/decred/config.py
+++ b/decred/decred/config.py
@@ -1,6 +1,6 @@
 """
 Copyright (c) 2019, Brian Stafford
-Copyright (c) 2019, the Decred developers
+Copyright (c) 2019-2020, the Decred developers
 See LICENSE for details
 
 Configuration settings for TinyDecred.
@@ -77,16 +77,16 @@ class TinyConfig:
         args, unknown = parser.parse_known_args()
         if unknown:
             log.warning("ignoring unknown arguments:", repr(unknown))
-        self.net = None
+        self.netParams = None
         if netName == SIMNET or args.simnet:
-            self.net = nets.simnet
+            self.netParams = nets.simnet
         elif netName in (TESTNET, "testnet") or args.testnet:
-            self.net = nets.testnet
+            self.netParams = nets.testnet
         else:
             print("**********************************************************")
             print(" WARNING. WALLET FOR TESTING ONLY. NOT FOR USE ON MAINNET ")
             print("**********************************************************")
-            self.net = nets.mainnet
+            self.netParams = nets.mainnet
         self.normalize()
 
     def set(self, k, v):
@@ -129,9 +129,9 @@ class TinyConfig:
         netKey = "networks"
         if netKey not in file:
             file[netKey] = {}
-        if self.net.Name not in file[netKey]:
-            d = file[netKey][self.net.Name] = tinyNetConfig(self.net.Name)
-            d["name"] = self.net.Name
+        if self.netParams.Name not in file[netKey]:
+            d = file[netKey][self.netParams.Name] = tinyNetConfig(self.netParams.Name)
+            d["name"] = self.netParams.Name
 
     def save(self):
         """

--- a/decred/decred/crypto/crypto.py
+++ b/decred/decred/crypto/crypto.py
@@ -186,8 +186,8 @@ class AddressSecpPubKey:
     def __init__(self, serializedPubkey, netParams):
         """
         Args:
-            serializedPubkey (curve.KoblitzCurve): A ByteArray corresponding
-                to the serialized compressed public key (33 bytes).
+            serializedPubkey (ByteArray): Corresponds to the serialized
+                compressed public key (33 bytes).
             netParams (module): The network parameters.
         """
         pubkey = Curve.parsePubKey(serializedPubkey)

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -831,7 +831,7 @@ class DcrdataBlockchain:
         Process a notification from the block explorer.
 
         Arg:
-            sig (object or string): The block explorer's notification, decoded.
+            sig (dict or string): The block explorer's notification, decoded.
         """
         # log.debug("pubsub signal recieved: %s" % repr(sig))
         if sig == WS_DONE:

--- a/decred/decred/dcr/vsp.py
+++ b/decred/decred/dcr/vsp.py
@@ -177,7 +177,7 @@ class VotingServiceProvider:
         # a call to VotingServiceProvider.authorize before using the
         # VotingServiceProvider.
         self.apiKey = apiKey
-        self.net = nets.parse(netName)
+        self.netParams = nets.parse(netName)
         self.purchaseInfo = purchaseInfo
         self.stats = None
         self.err = None
@@ -190,7 +190,7 @@ class VotingServiceProvider:
             encode.BuildyBytes(0)
             .addData(vsp.url.encode("utf-8"))
             .addData(vsp.apiKey.encode("utf-8"))
-            .addData(vsp.net.Name.encode("utf-8"))
+            .addData(vsp.netParams.Name.encode("utf-8"))
             .addData(encode.filterNone(pi))
             .b
         )
@@ -227,18 +227,18 @@ class VotingServiceProvider:
         return ByteArray(VotingServiceProvider.blob(self))
 
     @staticmethod
-    def providers(net):
+    def providers(netParams):
         """
         A static method to get the current Decred VSP list.
 
         Args:
-            net (string): The network name.
+            netParams (module): The network parameters.
 
         Returns:
             list(object): The vsp list.
         """
         vsps = tinyhttp.get("https://api.decred.org/?c=gsd")
-        network = nets.normalizeName(net.Name)
+        network = nets.normalizeName(netParams.Name)
         return [vsp for vsp in vsps.values() if vsp["Network"] == network]
 
     def apiPath(self, command):
@@ -274,7 +274,7 @@ class VotingServiceProvider:
         """
         pi = self.purchaseInfo
         redeemScript = pi.script
-        scriptAddr = crypto.newAddressScriptHash(redeemScript, self.net)
+        scriptAddr = crypto.newAddressScriptHash(redeemScript, self.netParams)
         if scriptAddr.string() != pi.ticketAddress:
             raise DecredError(
                 "ticket address mismatch. %s != %s"
@@ -282,12 +282,12 @@ class VotingServiceProvider:
             )
         # extract addresses
         scriptType, addrs, numSigs = txscript.extractPkScriptAddrs(
-            0, redeemScript, self.net
+            0, redeemScript, self.netParams
         )
         if numSigs != 1:
             raise DecredError("expected 2 required signatures, found 2")
         found = False
-        signAddr = txscript.decodeAddress(addr, self.net)
+        signAddr = txscript.decodeAddress(addr, self.netParams)
         for addr in addrs:
             if addr.string() == signAddr.string():
                 found = True

--- a/decred/decred/wallet/accounts.py
+++ b/decred/decred/wallet/accounts.py
@@ -69,7 +69,7 @@ class AccountManager:
 
         # The Scrypt parameters used to encrypt the crypto keys.
         self.netName = netName
-        self.net = self.netParams()
+        self.netParams = chains.NetworkParams[self.coinType][self.netName]
 
         self.watchingOnly = False
 
@@ -117,15 +117,6 @@ class AccountManager:
         """
         return encode.ByteArray(AccountManager.blob(self))
 
-    def netParams(self):
-        """
-        Get the network parameters for the account.
-
-        Returns:
-            module: The network parameters.
-        """
-        return chains.NetworkParams[self.coinType][self.netName]
-
     def load(self, db, signals):
         """
         Set up the database and set the UI signals.
@@ -153,7 +144,7 @@ class AccountManager:
         Returns:
             ByteArray:
         """
-        return crypto.decodeExtendedKey(self.net, cryptoKey, self.coinKeyEnc)
+        return crypto.decodeExtendedKey(self.netParams, cryptoKey, self.coinKeyEnc)
 
     def dbForAcctIdx(self, idx):
         """

--- a/decred/tests/unit/dcr/test_account.py
+++ b/decred/tests/unit/dcr/test_account.py
@@ -838,7 +838,7 @@ class TestAccount:
             def __init__(self):
                 self.signals = Dummy()
                 self.blockchain = Dummy()
-                self.net = nets.testnet
+                self.netParams = nets.testnet
 
         db = KeyValueDatabase(":memory:").child("tmp")
 
@@ -867,7 +867,9 @@ class TestAccount:
             voteTxid: newTinfo("vote"),
             revocationTxid: newTinfo("revocation"),
         }
-        acct.blockchain.ticketInfoForSpendingTx = lambda txid, net: txidToTinfo[txid]
+        acct.blockchain.ticketInfoForSpendingTx = lambda txid, netParams: txidToTinfo[
+            txid
+        ]
 
         tDB[ticketVotedTxid] = utxo
         tDB[ticketRevokedTxid] = utxo
@@ -907,7 +909,7 @@ class TestAccount:
                 self.mempool = {}
                 self.txs = {}
                 self.utxos = {}
-                self.net = nets.testnet
+                self.netParams = nets.testnet
 
         db = KeyValueDatabase(":memory:").child("tmp")
 
@@ -1069,7 +1071,7 @@ class TestAccount:
 
     def test_nextBranchAddress(self):
         class FakeExtendedKey:
-            def deriveChildAddress(self, i, net):
+            def deriveChildAddress(self, i, netParams):
                 raise crypto.CrazyKeyError
 
         db = KeyValueDatabase(":memory:").child("tmp")

--- a/decred/tests/unit/dcr/test_vsp_unit.py
+++ b/decred/tests/unit/dcr/test_vsp_unit.py
@@ -154,7 +154,7 @@ votingServiceProvider = {
 def assertVspIsEqual(pool):
     assert pool.url == votingServiceProvider["url"]
     assert pool.apiKey == votingServiceProvider["apiKey"]
-    assert pool.net.Name == votingServiceProvider["netName"]
+    assert pool.netParams.Name == votingServiceProvider["netName"]
     assertPiIsEqual(pool.purchaseInfo)
 
 

--- a/tinywallet/tinywallet/app.py
+++ b/tinywallet/tinywallet/app.py
@@ -107,7 +107,10 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
         # The initialized DcrdataBlockchain will not be connected, as that is a
         # blocking operation. It will be called when the wallet is open.
         self.dcrdata = DcrdataBlockchain(
-            dcrdataDB, self.cfg.net, self.getNetSetting("dcrdata"), skipConnect=True,
+            dcrdataDB,
+            self.cfg.netParams,
+            self.getNetSetting("dcrdata"),
+            skipConnect=True,
         )
         chains.registerChain("dcr", self.dcrdata)
 
@@ -257,7 +260,7 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
         Returns:
             str: Absolute filepath of the directory for the selected network.
         """
-        return os.path.join(config.DATA_DIR, self.cfg.net.Name)
+        return os.path.join(config.DATA_DIR, self.cfg.netParams.Name)
 
     def loadSettings(self):
         """
@@ -304,7 +307,7 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
         Returns:
             mixed: Value of network setting for *keys.
         """
-        return self.cfg.get("networks", self.cfg.net.Name, *keys)
+        return self.cfg.get("networks", self.cfg.netParams.Name, *keys)
 
     def setNetSetting(self, k, v):
         """
@@ -314,7 +317,7 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
             k (str): Network setting key string.
             v (value): Network setting value.
         """
-        self.cfg.get("networks", self.cfg.net.Name)[k] = v
+        self.cfg.get("networks", self.cfg.netParams.Name)[k] = v
 
     def registerSignal(self, sig, cb, *a, **k):
         """

--- a/tinywallet/tinywallet/screens.py
+++ b/tinywallet/tinywallet/screens.py
@@ -1,6 +1,6 @@
 """
 Copyright (c) 2019, Brian Stafford
-Copyright (c) 2019, the Decred developers
+Copyright (c) 2019-2020, the Decred developers
 See LICENSE for detail
 """
 
@@ -793,7 +793,7 @@ class InitializationScreen(Screen):
         def create():
             try:
                 app.dcrdata.connect()
-                words, wallet = Wallet.create(app.walletFilename(), pw, cfg.net)
+                words, wallet = Wallet.create(app.walletFilename(), pw, cfg.netParams)
                 return words, wallet
             except Exception as e:
                 log.error("failed to create wallet: %s" % formatTraceback(e))
@@ -1134,7 +1134,7 @@ class MnemonicRestorer(Screen):
             try:
                 app.dcrdata.connect()
                 wallet = Wallet.createFromMnemonic(
-                    words, app.walletFilename(), pw, cfg.net,
+                    words, app.walletFilename(), pw, cfg.netParams,
                 )
                 return wallet
             except Exception as e:
@@ -1494,7 +1494,7 @@ class LiveTicketsScreen(Screen):
         """
         utxo = self.liveTickets[item.text()[:8]]
         url = "https://{}.dcrdata.org/tx/{}".format(
-            nets.normalizeName(cfg.net.Name), utxo.txid
+            nets.normalizeName(cfg.netParams.Name), utxo.txid
         )
         helpers.openInBrowser(url)
 
@@ -1684,9 +1684,9 @@ class StakeStatsScreen(Screen):
         self.blkHeight.setText(str(tpinfo.height))
         self.networkTickets.setText(t(tpinfo.size, ", "))
         self.networkValue.setText("{:.2f} dcr".format(tpinfo.value))
-        blocksLeft = calc.blksLeftStakeWindow(cfg.net, tpinfo.height)
+        blocksLeft = calc.blksLeftStakeWindow(cfg.netParams, tpinfo.height)
         self.blocksLeft.setText(b(blocksLeft))
-        cache = calc.SubsidyCache(cfg.net)
+        cache = calc.SubsidyCache(cfg.netParams)
         self.stakebase.setText(r(cache.calcStakeVoteSubsidy(tpinfo.height), ", "))
 
         stakeDiff = blockchain.stakeDiff()
@@ -1842,11 +1842,11 @@ class PoolScreen(Screen):
         """
         Get the current master list of VSPs from decred.org.
         """
-        net = app.dcrdata.params
+        netParams = app.dcrdata.netParams
 
         def getvsp():
             try:
-                return VotingServiceProvider.providers(net)
+                return VotingServiceProvider.providers(netParams)
             except Exception as e:
                 log.error("error retrieving stake pools: %s" % e)
                 return False
@@ -1868,7 +1868,7 @@ class PoolScreen(Screen):
         # testing.
         # TODO: Have 3 tinydecred network constants retreivable through cfg
         #   instead of checking the network config's Name attribute.
-        if cfg.net.Name == "mainnet":
+        if cfg.netParams.Name == "mainnet":
             self.pools = [
                 p
                 for p in pools
@@ -1926,7 +1926,7 @@ class PoolScreen(Screen):
             err("invalid URL")
             return
         baseUrl = parsedURL.scheme + "://" + parsedURL.netloc
-        pool = VotingServiceProvider(baseUrl, apiKey, cfg.net.Name)
+        pool = VotingServiceProvider(baseUrl, apiKey, cfg.netParams.Name)
 
         def registerPool():
             try:


### PR DESCRIPTION
Currently the following names are used for variables referencing the network parameters modules:

`chain`, `chainParams`, `net`, `netParams`, `params`.

This PR changes them to always use `netParams`. It also updates the relevant docstrings and comments. I also made the matching comments in the wallet and tested it a bit.

I was careful to not change unrelated instances of `chain` and `params`; please check that I didn't break anything, and tell me if I missed some of the names.