### PR TITLE
crypto: fix encryption key authentication

### DIFF
--- a/decred/decred/crypto/crypto.py
+++ b/decred/decred/crypto/crypto.py
@@ -1225,8 +1225,8 @@ class SecretKey:
         b = ByteArray(
             hashlib.pbkdf2_hmac(kp.hashName, bytes(pw), bytes(kp.salt), kp.iterations)
         )
-        # Get the authentication message and key and compare create the code
-        # to compare with the included key parameters.
+        # Get the authentication message and key create the MAC tag to compare
+        # with the included key parameters.
         authKey = b[32:].bytes()
         authMsg = kp.baseParams().bytes()
         auth = hashlib.blake2b(authMsg, digest_size=32, key=authKey).digest()

--- a/decred/decred/crypto/crypto.py
+++ b/decred/decred/crypto/crypto.py
@@ -1087,26 +1087,18 @@ class KDFParams:
         auth (ByteArray): An authentication hash.
     """
 
-    def __init__(self, salt, auth):
+    def __init__(self, salt, auth=b""):
         self.salt = salt
-        self.auth = auth
         func, hn, its = defaultKDFParams()
         self.kdfFunc = func
         self.hashName = hn
         self.iterations = its
+        self.auth = auth
 
     @staticmethod
     def blob(params):
         """Satisfies the encode.Blobber API"""
-        return (
-            encode.BuildyBytes(0)
-            .addData(params.kdfFunc.encode("utf-8"))
-            .addData(params.hashName.encode("utf-8"))
-            .addData(params.salt)
-            .addData(params.auth)
-            .addData(params.iterations)
-            .b
-        )
+        return params.baseParams().addData(params.auth).b
 
     @staticmethod
     def unblob(b):
@@ -1114,13 +1106,28 @@ class KDFParams:
         ver, d = encode.decodeBlob(b)
         unblobCheck("KDFParams", ver, len(d), {0: 5})
 
-        params = KDFParams(salt=ByteArray(d[2]), auth=ByteArray(d[3]))
+        params = KDFParams(salt=ByteArray(d[2]), auth=ByteArray(d[4]))
 
         params.kdfFunc = d[0].decode("utf-8")
         params.hashName = d[1].decode("utf-8")
-        params.iterations = encode.intFromBytes(d[4])
+        params.iterations = encode.intFromBytes(d[3])
 
         return params
+
+    def baseParams(self):
+        """
+        Serializes all the parameters except the authentication code.
+
+        Returns:
+            BuildyBytes: The serialized parameters.
+        """
+        return (
+            encode.BuildyBytes(0)
+            .addData(self.kdfFunc.encode("utf-8"))
+            .addData(self.hashName.encode("utf-8"))
+            .addData(self.salt)
+            .addData(self.iterations)
+        )
 
     def serialize(self):
         """
@@ -1138,19 +1145,30 @@ class SecretKey:
     decryption.
     """
 
-    def __init__(self, pw):
+    def __init__(self, pw=None):
         """
         Args:
             pw (byte-like): A password that deterministically generates the key.
         """
         super().__init__()
+        if not pw:
+            self.key = None
+            self.keyParams = None
+            return
+        # If a password was provided, create a new set of key parameters and an
+        # authentication code.
         salt = rando.newKey()
-        b = lambda v: ByteArray(v).bytes()
         _, hashName, iterations = defaultKDFParams()
-        b = ByteArray(hashlib.pbkdf2_hmac(hashName, b(pw), salt.bytes(), iterations))
+        b = ByteArray(
+            hashlib.pbkdf2_hmac(hashName, bytes(pw), salt.bytes(), iterations)
+        )
         self.key = b[:32]
-        auth = ByteArray(hashlib.sha256(b[32:].b).digest())
-        self.keyParams = KDFParams(salt, auth)
+        self.keyParams = KDFParams(salt)
+        authKey = b[32:].bytes()
+        authMsg = self.keyParams.baseParams().bytes()
+        self.keyParams.auth = ByteArray(
+            hashlib.blake2b(authMsg, digest_size=32, key=authKey).digest()
+        )
 
     def params(self):
         """
@@ -1187,33 +1205,36 @@ class SecretKey:
         return ByteArray(decrypt(self.key, thing))
 
     @staticmethod
-    def rekey(password, kp):
+    def rekey(pw, kp):
         """
         Regenerate a key using its origin key parameters, as returned by
         `params`.
 
         Args:
-            password (bytes-like): The key password.
+            pw (bytes-like): The key password.
             kp (KDFParams): The key parameters from the original generation
                 of the key being regenerated.
 
         Returns:
             SecretKey: The regenerated key.
         """
-        sk = SecretKey(b"")
-        sk.keyParams = kp
+        sk = SecretKey()
         func = kp.kdfFunc
         if func != "pbkdf2_hmac":
             raise DecredError("unknown key derivation function")
         b = ByteArray(
-            hashlib.pbkdf2_hmac(
-                kp.hashName, bytes(password), bytes(kp.salt), kp.iterations
-            )
+            hashlib.pbkdf2_hmac(kp.hashName, bytes(pw), bytes(kp.salt), kp.iterations)
         )
-        sk.key = b[:32]
-        checkAuth = ByteArray(hashlib.sha256(b[32:].b).digest())
-        if checkAuth != kp.auth:
+        # Get the authentication message and key and compare create the code
+        # to compare with the included key parameters.
+        authKey = b[32:].bytes()
+        authMsg = kp.baseParams().bytes()
+        auth = hashlib.blake2b(authMsg, digest_size=32, key=authKey).digest()
+        if auth != kp.auth:
             raise DecredError("rekey auth check failed")
+
+        sk.key = b[:32]
+        sk.keyParams = kp
         return sk
 
 
@@ -1236,7 +1257,7 @@ def encrypt(key, thing):
     # nonce alongside it.
     encrypted = box.encrypt(bytes(thing))
 
-    if len(encrypted) != len(thing) + box.NONCE_SIZE + box.MACBYTES:
+    if len(encrypted) != len(thing) + box.NONCE_SIZE + box.MACBYTES:  # nocover
         raise DecredError("wrong encrypted length %d" % len(encrypted))
 
     return ByteArray(encrypted)

--- a/decred/decred/wallet/wallet.py
+++ b/decred/decred/wallet/wallet.py
@@ -14,15 +14,12 @@ from . import accounts
 
 log = helpers.getLogger("WLLT")
 
-CHECKPHRASE = "tinydecred".encode("utf-8")
-
 BipIDs = chains.BipIDs
 
 
 class DBKeys:
     cryptoKey = "cryptoKey".encode("utf-8")
     root = "root".encode("utf-8")
-    checkKey = "checkKey".encode("utf-8")
     keyParams = "keyParams".encode("utf-8")
 
 
@@ -69,7 +66,6 @@ class Wallet:
         root = crypto.ExtendedKey.new(seed)
         self.masterDB[DBKeys.cryptoKey] = pwKey.encrypt(cryptoKey)
         self.masterDB[DBKeys.root] = root.serialize()
-        self.masterDB[DBKeys.checkKey] = pwKey.encrypt(CHECKPHRASE)
         self.masterDB[DBKeys.keyParams] = crypto.ByteArray(pwKey.params().serialize())
         db = self.coinDB.child(str(BipIDs.decred), table=False)
         acctManager = accounts.createNewAccountManager(
@@ -139,9 +135,6 @@ class Wallet:
         if not self.keyParams:
             self.keyParams = crypto.KDFParams.unblob(self.masterDB[DBKeys.keyParams].b)
         pwKey = crypto.SecretKey.rekey(password.encode(), self.keyParams)
-        checkPhrase = pwKey.decrypt(self.masterDB[DBKeys.checkKey])
-        if checkPhrase != CHECKPHRASE:
-            raise DecredError("wrong password")
         return pwKey.decrypt(self.masterDB[DBKeys.cryptoKey])
 
     def accountManager(self, coinType, signals):

--- a/decred/tests/unit/crypto/test_crypto.py
+++ b/decred/tests/unit/crypto/test_crypto.py
@@ -122,14 +122,14 @@ class TestCrypto(unittest.TestCase):
 
     def test_kdf_params(self):
         salt = rando.newHash()
-        digest = ByteArray(32)
-        kdf = crypto.KDFParams(salt, digest)
+        auth = ByteArray(32)
+        kdf = crypto.KDFParams(salt, auth)
         b = kdf.serialize()
         reKDF = crypto.KDFParams.unblob(b.b)
         self.assertEqual(kdf.kdfFunc, reKDF.kdfFunc)
         self.assertEqual(kdf.hashName, reKDF.hashName)
         self.assertEqual(kdf.salt, reKDF.salt)
-        self.assertEqual(kdf.digest, reKDF.digest)
+        self.assertEqual(kdf.auth, reKDF.auth)
         self.assertEqual(kdf.iterations, reKDF.iterations)
 
     def test_secret_key(self):


### PR DESCRIPTION
The checkphrase check really should never have been there. The key params already include a hash that is used to verify the key in SecretKey.rekey. Also reworked the key authentication based on a [previous conversation](https://github.com/decred/dcrdex/pull/155#discussion_r373119966) in dcrdex.

Will need to nuke your wallet, since the old password parameters won't work anymore.