### PR TITLE
addrlib: move Address types to separate module

### DIFF
--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -6,7 +6,7 @@ See LICENSE for details
 
 from decred import DecredError
 from decred.crypto import crypto, opcode
-from decred.dcr import dcraddr
+from decred.dcr import addrlib
 from decred.util import encode, helpers
 from decred.util.encode import BuildyBytes, ByteArray, unblobCheck
 
@@ -67,7 +67,7 @@ def deriveChildAddress(branchXPub, i, netParams):
         Address: Child address.
     """
     child = branchXPub.child(i)
-    return dcraddr.newAddressPubKeyHash(
+    return addrlib.AddressPubKeyHash(
         crypto.hash160(child.publicKey().serializeCompressed().b),
         netParams,
         crypto.STEcdsaSecp256k1,
@@ -575,7 +575,7 @@ class UTXO:
         rawaddr = txscript.extractStakeScriptHash(
             txout.pkScript, opcode.OP_SSTX
         ).bytes()
-        addr = dcraddr.AddressScriptHash(netParams.ScriptHashAddrID, rawaddr).string()
+        addr = addrlib.AddressScriptHash(rawaddr, netParams).string()
         ticket = UTXO(
             address=addr,
             txHash=tx.cachedHash(),
@@ -1738,7 +1738,7 @@ class Account:
         Returns:
             AddressSecpPubkey: The address object.
         """
-        return dcraddr.AddressSecpPubKey(
+        return addrlib.AddressSecpPubKey(
             self.votingKey().pub.serializeCompressed(), self.netParams
         )
 
@@ -1946,9 +1946,9 @@ class Account:
         )
         txs = [self.blockchain.tx(txid) for txid in revocableTickets]
         for tx in txs:
-            redeemHash = dcraddr.AddressScriptHash(
-                self.netParams.ScriptHashAddrID,
+            redeemHash = addrlib.AddressScriptHash(
                 txscript.extractStakeScriptHash(tx.txOut[0].pkScript, opcode.OP_SSTX),
+                self.netParams,
             )
             redeemScript = next(
                 (

--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -6,6 +6,7 @@ See LICENSE for details
 
 from decred import DecredError
 from decred.crypto import crypto, opcode
+from decred.dcr import dcraddr
 from decred.util import encode, helpers
 from decred.util.encode import BuildyBytes, ByteArray, unblobCheck
 
@@ -52,6 +53,25 @@ def filterCrazyAddress(addrs):
         list(str): The filtered addresses.
     """
     return [a for a in addrs if a != CrazyAddress]
+
+
+def deriveChildAddress(branchXPub, i, netParams):
+    """
+    The base-58 encoded address for the i'th child.
+
+    Args:
+        i (int): Child number.
+        netParams (module): Network parameters.
+
+    Returns:
+        Address: Child address.
+    """
+    child = branchXPub.child(i)
+    return dcraddr.newAddressPubKeyHash(
+        crypto.hash160(child.publicKey().serializeCompressed().b),
+        netParams,
+        crypto.STEcdsaSecp256k1,
+    ).string()
 
 
 class KeySource:
@@ -555,7 +575,7 @@ class UTXO:
         rawaddr = txscript.extractStakeScriptHash(
             txout.pkScript, opcode.OP_SSTX
         ).bytes()
-        addr = crypto.AddressScriptHash(netParams.ScriptHashAddrID, rawaddr).string()
+        addr = dcraddr.AddressScriptHash(netParams.ScriptHashAddrID, rawaddr).string()
         ticket = UTXO(
             address=addr,
             txHash=tx.cachedHash(),
@@ -889,11 +909,11 @@ class Account:
         extPub = pubX.child(EXTERNAL_BRANCH)
         intPub = pubX.child(INTERNAL_BRANCH)
         addrs = [
-            extPub.deriveChildAddress(idx, blockchain.params)
+            deriveChildAddress(extPub, idx, blockchain.params)
             for idx in range(DefaultGapLimit)
         ]
         addrs += [
-            intPub.deriveChildAddress(idx, blockchain.params)
+            deriveChildAddress(intPub, idx, blockchain.params)
             for idx in range(DefaultGapLimit)
         ]
         return blockchain.addrsHaveTxs(addrs)
@@ -1400,7 +1420,7 @@ class Account:
         def nextAddr():
             idx = len(branchAddrs)
             try:
-                addr = branchKey.deriveChildAddress(idx, self.netParams)
+                addr = deriveChildAddress(branchKey, idx, self.netParams)
             except crypto.CrazyKeyError:
                 addr = CrazyAddress
             branchAddrs.append(addr)
@@ -1718,7 +1738,7 @@ class Account:
         Returns:
             AddressSecpPubkey: The address object.
         """
-        return crypto.AddressSecpPubKey(
+        return dcraddr.AddressSecpPubKey(
             self.votingKey().pub.serializeCompressed(), self.netParams
         )
 
@@ -1926,7 +1946,7 @@ class Account:
         )
         txs = [self.blockchain.tx(txid) for txid in revocableTickets]
         for tx in txs:
-            redeemHash = crypto.AddressScriptHash(
+            redeemHash = dcraddr.AddressScriptHash(
                 self.netParams.ScriptHashAddrID,
                 txscript.extractStakeScriptHash(tx.txOut[0].pkScript, opcode.OP_SSTX),
             )

--- a/decred/decred/dcr/addrlib.py
+++ b/decred/decred/dcr/addrlib.py
@@ -151,7 +151,7 @@ class AddressPubKeyHash(Address):
         Returns:
             str: The encoded address.
         """
-        return encodeAddress(self.netID, self.pkHash)
+        return encodeAddress(self.pkHash, self.netID)
 
     def address(self):
         """
@@ -264,7 +264,7 @@ class AddressSecpPubKey(Address):
         Returns:
             str: base-58 encoded p2pkh address.
         """
-        return encodeAddress(self.pubkeyHashID, hash160(self.serialize().bytes()))
+        return encodeAddress(hash160(self.serialize().bytes()), self.pubkeyHashID)
 
     def scriptAddress(self):
         """
@@ -329,7 +329,7 @@ class AddressScriptHash(Address):
         Returns:
             str: The encoded address.
         """
-        return encodeAddress(self.netID, self.scriptHash)
+        return encodeAddress(self.scriptHash, self.netID)
 
     def address(self):
         """
@@ -374,13 +374,13 @@ class AddressSecSchnorrPubKey(Address):
         raise NotImplementedError("AddressSecSchnorrPubKey implemented")
 
 
-def encodeAddress(netID, k):
+def encodeAddress(k, netID):
     """
     Base-58 encode the number, with the netID prepended byte-wise.
 
     Args:
-        netID (byte-like): The addresses network encoding ID.
         k (ByteArray): The pubkey or pubkey-hash or script-hash.
+        netID (byte-like): The addresses network encoding ID.
 
     Returns:
         string: Base-58 encoded address.
@@ -440,9 +440,9 @@ def decodeAddressPubKey(decoded, netParams):
     if suite == STEcdsaSecp256k1:
         b = ByteArray(toAppend) + decoded[1:]
         return AddressSecpPubKey(b, netParams)
-    elif suite == STEd25519:  # nocover
+    elif suite == STEd25519:
         raise NotImplementedError("Edwards signatures not implemented")
-    elif suite == STSchnorrSecp256k1:  # nocover
+    elif suite == STSchnorrSecp256k1:
         raise NotImplementedError("Schnorr signatures not implemented")
     else:
         raise NotImplementedError(f"unknown address type {suite}")

--- a/decred/decred/dcr/addrlib.py
+++ b/decred/decred/dcr/addrlib.py
@@ -1,0 +1,447 @@
+"""
+Copyright (c) 2019, Brian Stafford
+Copyright (c) 2019-2020, The Decred developers
+See LICENSE for details
+
+Cryptographic functions.
+"""
+
+
+from base58 import b58encode
+
+from decred import DecredError
+from decred.crypto.crypto import (
+    RIPEMD160_SIZE,
+    PKFCompressed,
+    PKFUncompressed,
+    STEcdsaSecp256k1,
+    STEd25519,
+    STSchnorrSecp256k1,
+    b58CheckDecode,
+    checksum,
+    hash160,
+)
+from decred.crypto.secp256k1.curve import curve as Secp256k1
+from decred.dcr import nets
+from decred.util.encode import BuildyBytes, ByteArray, decodeBlob, unblobCheck
+
+
+class Address:
+    """
+    A parent class for all addresses. This class specifies an API that all
+    child classes should implement.
+    """
+
+    def __init__(self, chainParams):
+        """
+        Args:
+            chainParams (module): The network parameters.
+        """
+        self.netName = chainParams.Name
+
+    @staticmethod
+    def blob(addr):
+        """Satisfies the encode.Blobber API"""
+        aEnc = addr.string().encode()
+        netEnc = addr.netName.encode()
+        return BuildyBytes(0).addData(netEnc).addData(aEnc).b
+
+    @staticmethod
+    def unblob(b):
+        """Satisfies the encode.Blobber API"""
+        ver, d = decodeBlob(b)
+        unblobCheck("Address", ver, len(d), {0: 2})
+        return decodeAddress(d[1].decode(), nets.parse(d[0].decode()))
+
+    def __eq__(self, a):
+        """Check that other address is equivalent to this address."""
+        raise NotImplementedError("__eq__ must be implemented by child class")
+
+    def string(self):
+        """
+        The base-58 encoding of the address.
+
+        Note that string() differs subtly from address(): string() will return
+        the value as a string without any conversion, while address() may
+        convert destination types (for example, converting pubkeys to P2PKH
+        addresses) before encoding as a payment address string.
+
+        Returns:
+            str: The encoded address.
+        """
+        raise NotImplementedError("string must be implemented by child class")
+
+    def address(self):
+        """
+        The string encoding of the payment address associated with the Address
+        value
+
+        Returns:
+            str: The encoded address.
+        """
+        raise NotImplementedError("address must be implemented by child class")
+
+    def scriptAddress(self):
+        """
+        The raw bytes of the address to be used when inserting the address into
+        a txout's script.
+
+        Returns:
+            ByteArray: The script address.
+        """
+
+        raise NotImplementedError("scriptAddress must be implemented by child class")
+
+    def hash160(self):
+        """
+        The Hash160(data) where data is the data normally hashed to 160 bits
+        from the respective address type.
+
+        Returns:
+            ByteArray: The hash.
+        """
+        raise NotImplementedError("hash160 must be implemented by child class")
+
+
+class AddressPubKeyHash(Address):
+    """
+    Address based on a pubkey hash.
+    """
+
+    def __init__(self, pkHash=None, netParams=None, sigType=STEcdsaSecp256k1):
+        """
+        Args:
+            pkHash (ByteArray): The hashed pubkey.
+            netParams (module): The network parameters.
+            sigType (int): The signature type.
+        """
+
+        if sigType == STEd25519:  # nocover
+            raise NotImplementedError("Edwards not implemented")
+        elif sigType == STSchnorrSecp256k1:  # nocover
+            raise NotImplementedError("Schnorr not implemented")
+        elif sigType != STEcdsaSecp256k1:
+            raise NotImplementedError(f"unsupported signature type {sigType}")
+
+        super().__init__(netParams)
+        pkh_len = len(pkHash)
+        if pkh_len != 20:
+            raise DecredError(f"AddressPubKeyHash expected 20 bytes, got {pkh_len}")
+
+        self.sigType = sigType
+        self.netID = netParams.PubKeyHashAddrID
+        self.pkHash = pkHash
+
+    def __eq__(self, a):
+        """Check that other address is equivalent to this address."""
+        if isinstance(a, str):
+            return a == self.string()
+        elif isinstance(a, AddressPubKeyHash):
+            return (
+                a.pkHash == self.pkHash
+                and a.netID == self.netID
+                and a.sigType == self.sigType
+            )
+        return False
+
+    def string(self):
+        """
+        A base-58 encoding of the pubkey hash.
+
+        Returns:
+            str: The encoded address.
+        """
+        return encodeAddress(self.netID, self.pkHash)
+
+    def address(self):
+        """
+        The string encoding of a pay-to-pubkey-hash address.
+
+        Returns:
+            str: The encoded address.
+        """
+        return self.string()
+
+    def scriptAddress(self):
+        """
+        The raw bytes of the address to be used when inserting the address into
+        a txout's script.
+
+        Returns:
+            ByteArray: The script address.
+        """
+        return self.pkHash.copy()
+
+    def hash160(self):
+        """
+        For AddressPubKeyHash, hash160 is the same as scriptAddress.
+
+        Returns:
+            ByteArray: The hash.
+        """
+        return self.pkHash.copy()
+
+
+class AddressSecpPubKey(Address):
+    """
+    An address based on an unhashed public key.
+    """
+
+    def __init__(self, serializedPubkey, netParams):
+        """
+        Args:
+            serializedPubkey (ByteArray): Corresponds to the serialized
+                compressed public key (33 bytes).
+            netParams (module): The network parameters.
+        """
+        super().__init__(netParams)
+        pubkey = Secp256k1.parsePubKey(serializedPubkey)
+        # Set the format of the pubkey.  We already know the pubkey is valid
+        # since it parsed above, so it's safe to simply examine the leading
+        # byte to get the format.
+        fmt = serializedPubkey[0]
+        if fmt in (0x02, 0x03):
+            pkFormat = PKFCompressed
+        elif fmt == 0x04:
+            pkFormat = PKFUncompressed
+        else:
+            raise NotImplementedError(f"unknown pubkey format {fmt}")
+        self.pubkeyFormat = pkFormat
+        self.netID = self.pubkeyID = netParams.PubKeyAddrID
+        self.pubkeyHashID = netParams.PubKeyHashAddrID
+        self.pubkey = pubkey
+
+    def __eq__(self, a):
+        """Check that other address is equivalent to this address."""
+        if isinstance(a, str):
+            return a == self.address() or a == self.string()
+        elif isinstance(a, AddressSecpPubKey):
+            return self.pubkey.serializeCompressed() == a.pubkey.serializeCompressed()
+        return False
+
+    def serialize(self):
+        """
+        The serialization of the public key according to the format associated
+        with the address.
+
+        Returns:
+            ByteArray: The serialized publid key.
+        """
+        fmt = self.pubkeyFormat
+        if fmt == PKFUncompressed:
+            return self.pubkey.serializeUncompressed()
+        elif fmt == PKFCompressed:
+            return self.pubkey.serializeCompressed()
+        raise NotImplementedError(f"unknown pubkey format {fmt}")
+
+    def string(self):
+        """
+        A base-58 encoding of the pubkey.
+
+        Returns:
+            str: The encoded address.
+        """
+        encoded = ByteArray(self.pubkeyID)
+        buf = ByteArray(STEcdsaSecp256k1, length=1)
+        compressed = self.pubkey.serializeCompressed()
+        # set the y-bit if needed
+        if compressed[0] == 0x03:
+            buf[0] |= 1 << 7
+        buf += compressed[1:]
+        encoded += buf
+        encoded += checksum(encoded.b)
+        return b58encode(encoded.bytes()).decode()
+
+    def address(self):
+        """
+        The string encoding of the public key as a pay-to-pubkey-hash.  Note
+        that the public key format (uncompressed, compressed, etc) will change
+        the resulting address.  This is expected since pay-to-pubkey-hash is a
+        hash of the serialized public key which obviously differs with the
+        format.  At the time of this writing, most Decred addresses are
+        pay-to-pubkey-hash constructed from the compressed public key.
+
+        Returns:
+            str: base-58 encoded p2pkh address.
+        """
+        return encodeAddress(self.pubkeyHashID, hash160(self.serialize().bytes()))
+
+    def scriptAddress(self):
+        """
+        The raw bytes of the address to be used when inserting the address into
+        a txout's script.
+
+        Returns:
+            ByteArray: The script address.
+        """
+        return self.serialize()
+
+    def hash160(self):
+        """
+        The hash160 of the serialized pubkey.
+
+        Returns:
+            ByteArray: The hash.
+        """
+        return hash160(self.serialize().bytes())
+
+
+class AddressScriptHash(Address):
+    """
+    AddressScriptHash is an Address for a pay-to-script-hash (P2SH) transaction.
+    """
+
+    def __init__(self, scriptHash, netParams):
+
+        if len(scriptHash) != RIPEMD160_SIZE:
+            raise DecredError(f"incorrect script hash length {len(scriptHash)}")
+
+        super().__init__(netParams)
+        self.netID = netParams.ScriptHashAddrID
+        self.scriptHash = scriptHash
+
+    @staticmethod
+    def fromScript(script, netParams):
+        """
+        Create a new AddressScriptHash from a redeem script.
+
+        Args:
+            script (ByteArray): the redeem script
+            netParams (module): the network parameters
+
+        Returns:
+            AddressScriptHash: An address object.
+        """
+        return AddressScriptHash(hash160(script.b), netParams)
+
+    def __eq__(self, a):
+        """Check that other address is equivalent to this address."""
+        if isinstance(a, str):
+            return a == self.string()
+        elif isinstance(a, AddressScriptHash):
+            return a.scriptHash == self.scriptHash and a.netID == self.netID
+        return False
+
+    def string(self):
+        """
+        A base-58 encoding of the pubkey hash.
+
+        Returns:
+            str: The encoded address.
+        """
+        return encodeAddress(self.netID, self.scriptHash)
+
+    def address(self):
+        """
+        The string encoding of a pay-to-script-hash address.
+
+        Returns:
+            str: The encoded address.
+        """
+        return self.string()
+
+    def scriptAddress(self):
+        """
+        The raw bytes of the address to be used when inserting the address into
+        a txout's script.
+
+        Returns:
+            ByteArray: The script address.
+        """
+        return self.scriptHash.copy()
+
+    def hash160(self):
+        """
+        A copy of the scriptHash.
+
+        Returns:
+            ByteArray: The hash.
+        """
+        return self.scriptHash.copy()
+
+
+class AddressEdwardsPubKey(Address):
+    """unimplemented"""
+
+    def __init__(*a, **k):
+        raise NotImplementedError("AddressEdwardsPubKey not implemented")
+
+
+class AddressSecSchnorrPubKey(Address):
+    """unimplemented"""
+
+    def __init__(*a, **k):
+        raise NotImplementedError("AddressSecSchnorrPubKey implemented")
+
+
+def encodeAddress(netID, k):
+    """
+    Base-58 encode the number, with the netID prepended byte-wise.
+
+    Args:
+        netID (byte-like): The addresses network encoding ID.
+        k (ByteArray): The pubkey or pubkey-hash or script-hash.
+
+    Returns:
+        string: Base-58 encoded address.
+    """
+    b = ByteArray(netID)
+    b += k
+    b += checksum(b.b)
+    return b58encode(b.bytes()).decode()
+
+
+def decodeAddress(addr, netParams):
+    """
+    DecodeAddress decodes the base-58 encoded address and returns the Address if
+    it is a valid encoding for a known address type and is for the provided
+    network.
+
+    Args:
+        netParams (module): The network parameters.
+    """
+    # Switch on decoded length to determine the type.
+    decoded, netID = b58CheckDecode(addr)
+    if netID == netParams.PubKeyAddrID:
+        return decodeAddressPubKey(decoded, netParams)
+    elif netID == netParams.PubKeyHashAddrID:
+        return AddressPubKeyHash(decoded, netParams, STEcdsaSecp256k1)
+    elif netID == netParams.PKHEdwardsAddrID:
+        raise NotImplementedError("Edwards signatures not implemented")
+    elif netID == netParams.PKHSchnorrAddrID:
+        raise NotImplementedError("Schnorr signatures not implemented")
+    elif netID == netParams.ScriptHashAddrID:
+        return AddressScriptHash(decoded, netParams)
+    raise NotImplementedError(f"unknown network ID {netID}")
+
+
+def decodeAddressPubKey(decoded, netParams):
+    """
+    decodeAddressPubKey decodes a pubkey-type address from the serialized
+    pubkey.
+
+    Args:
+        decoded (bytes): A 33 bytes decoded pubkey such as would be decoded
+            from a base58 string. The first byte indicates the signature suite.
+            For compressed secp256k1 pubkeys, use AddressSecpPubKey directly.
+        netParams (module): The network parameters.
+    """
+    if len(decoded) != 33:
+        raise NotImplementedError(f"unable to decode pubkey of length {len(decoded)}")
+    # First byte is the signature suite and ybit.
+    suite = decoded[0]
+    suite &= 127
+    ybit = not (decoded[0] & (1 << 7) == 0)
+    toAppend = 0x02
+    if ybit:
+        toAppend = 0x03
+
+    if suite == STEcdsaSecp256k1:
+        b = ByteArray(toAppend) + decoded[1:]
+        return AddressSecpPubKey(b, netParams)
+        # return NewAddressEdwardsPubKey(decoded, netParams)
+        raise NotImplementedError("Edwards signatures not implemented")
+    elif suite == STSchnorrSecp256k1:  # nocover
+        raise NotImplementedError("Schnorr signatures not implemented")
+    else:
+        raise NotImplementedError(f"unknown address type {suite}")

--- a/decred/decred/dcr/addrlib.py
+++ b/decred/decred/dcr/addrlib.py
@@ -398,6 +398,7 @@ def decodeAddress(addr, netParams):
     network.
 
     Args:
+        addr (str): Base-58 encoded address.
         netParams (module): The network parameters.
     """
     # Switch on decoded length to determine the type.
@@ -439,7 +440,7 @@ def decodeAddressPubKey(decoded, netParams):
     if suite == STEcdsaSecp256k1:
         b = ByteArray(toAppend) + decoded[1:]
         return AddressSecpPubKey(b, netParams)
-        # return NewAddressEdwardsPubKey(decoded, netParams)
+    elif suite == STEd25519:  # nocover
         raise NotImplementedError("Edwards signatures not implemented")
     elif suite == STSchnorrSecp256k1:  # nocover
         raise NotImplementedError("Schnorr signatures not implemented")

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -14,7 +14,7 @@ from urllib.parse import urlencode, urljoin, urlsplit, urlunsplit
 
 from decred import DecredError
 from decred.crypto import crypto
-from decred.dcr import dcraddr
+from decred.dcr import addrlib
 from decred.util import database, tinyhttp, ws
 from decred.util.encode import ByteArray
 from decred.util.helpers import formatTraceback, getLogger
@@ -1191,7 +1191,7 @@ class DcrdataBlockchain:
         if not req.poolAddress:
             raise DecredError("no pool address specified. solo voting not supported")
 
-        poolAddress = txscript.decodeAddress(req.poolAddress, self.netParams)
+        poolAddress = addrlib.decodeAddress(req.poolAddress, self.netParams)
 
         # Check the passed address from the request.
         if not req.votingAddress:
@@ -1200,13 +1200,13 @@ class DcrdataBlockchain:
         # decode the string addresses. This is the P2SH multi-sig script
         # address, not the wallets voting address, which is only one of the two
         # pubkeys included in the redeem P2SH script.
-        votingAddress = txscript.decodeAddress(req.votingAddress, self.netParams)
+        votingAddress = addrlib.decodeAddress(req.votingAddress, self.netParams)
 
         # The stake submission pkScript is tagged by an OP_SSTX.
-        if isinstance(votingAddress, dcraddr.AddressScriptHash):
+        if isinstance(votingAddress, addrlib.AddressScriptHash):
             stakeSubmissionPkScriptSize = txscript.P2SHPkScriptSize + 1
         elif (
-            isinstance(votingAddress, dcraddr.AddressPubKeyHash)
+            isinstance(votingAddress, addrlib.AddressPubKeyHash)
             and votingAddress.sigType == crypto.STEcdsaSecp256k1
         ):
             stakeSubmissionPkScriptSize = txscript.P2PKHPkScriptSize + 1
@@ -1318,7 +1318,7 @@ class DcrdataBlockchain:
                 pkScript=txOut.pkScript,
             )
 
-            addrSubsidy = txscript.decodeAddress(keysource.internal(), self.netParams)
+            addrSubsidy = addrlib.decodeAddress(keysource.internal(), self.netParams)
 
             # Generate the ticket msgTx and sign it.
             ticket = txscript.makeTicket(

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -14,6 +14,7 @@ from urllib.parse import urlencode, urljoin, urlsplit, urlunsplit
 
 from decred import DecredError
 from decred.crypto import crypto
+from decred.dcr import dcraddr
 from decred.util import database, tinyhttp, ws
 from decred.util.encode import ByteArray
 from decred.util.helpers import formatTraceback, getLogger
@@ -1202,10 +1203,10 @@ class DcrdataBlockchain:
         votingAddress = txscript.decodeAddress(req.votingAddress, self.netParams)
 
         # The stake submission pkScript is tagged by an OP_SSTX.
-        if isinstance(votingAddress, crypto.AddressScriptHash):
+        if isinstance(votingAddress, dcraddr.AddressScriptHash):
             stakeSubmissionPkScriptSize = txscript.P2SHPkScriptSize + 1
         elif (
-            isinstance(votingAddress, crypto.AddressPubKeyHash)
+            isinstance(votingAddress, dcraddr.AddressPubKeyHash)
             and votingAddress.sigType == crypto.STEcdsaSecp256k1
         ):
             stakeSubmissionPkScriptSize = txscript.P2PKHPkScriptSize + 1

--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -11,6 +11,7 @@ import math
 from decred import DecredError
 from decred.crypto import crypto, opcode
 from decred.crypto.secp256k1.curve import curve as Curve
+from decred.dcr import dcraddr
 from decred.util import helpers
 from decred.util.encode import ByteArray
 
@@ -1698,7 +1699,7 @@ def payToAddrScript(addr):
     PayToAddrScript creates a new script to pay a transaction output to a the
     specified address.
     """
-    if isinstance(addr, crypto.AddressPubKeyHash):
+    if isinstance(addr, dcraddr.AddressPubKeyHash):
         if addr.sigType == crypto.STEcdsaSecp256k1:
             return payToPubKeyHashScript(addr.scriptAddress())
         elif addr.sigType == crypto.STEd25519:
@@ -1709,17 +1710,17 @@ def payToAddrScript(addr):
             raise NotImplementedError("Schnorr signatures not implemented")
         raise NotImplementedError("unknown signature type %d" % addr.sigType)
 
-    elif isinstance(addr, crypto.AddressScriptHash):
+    elif isinstance(addr, dcraddr.AddressScriptHash):
         return payToScriptHashScript(addr.scriptAddress())
 
-    elif isinstance(addr, crypto.AddressSecpPubKey):
+    elif isinstance(addr, dcraddr.AddressSecpPubKey):
         return payToPubKeyScript(addr.scriptAddress())
 
-    elif isinstance(addr, crypto.AddressEdwardsPubKey):
+    elif isinstance(addr, dcraddr.AddressEdwardsPubKey):
         # return payToEdwardsPubKeyScript(addr.ScriptAddress())
         raise NotImplementedError("Edwards signatures not implemented")
 
-    elif isinstance(addr, crypto.AddressSecSchnorrPubKey):
+    elif isinstance(addr, dcraddr.AddressSecSchnorrPubKey):
         # return payToSchnorrPubKeyScript(addr.ScriptAddress())
         raise NotImplementedError("Schnorr signatures not implemented")
 
@@ -1812,13 +1813,13 @@ def payToSStx(addr):
     # Only pay to pubkey hash and pay to script hash are
     # supported.
     scriptType = PubKeyHashTy
-    if isinstance(addr, crypto.AddressPubKeyHash):
+    if isinstance(addr, dcraddr.AddressPubKeyHash):
         if addr.sigType != crypto.STEcdsaSecp256k1:
             raise NotImplementedError(
                 "unable to generate payment script for "
                 "unsupported digital signature algorithm"
             )
-    elif isinstance(addr, crypto.AddressScriptHash):
+    elif isinstance(addr, dcraddr.AddressScriptHash):
         scriptType = ScriptHashTy
     else:
         raise NotImplementedError(
@@ -1883,13 +1884,13 @@ def generateSStxAddrPush(addr, amount, limits):
     # Only pay to pubkey hash and pay to script hash are
     # supported.
     scriptType = PubKeyHashTy
-    if isinstance(addr, crypto.AddressPubKeyHash):
+    if isinstance(addr, dcraddr.AddressPubKeyHash):
         if addr.sigType != crypto.STEcdsaSecp256k1:
             raise NotImplementedError(
                 "unable to generate payment script for "
                 "unsupported digital signature algorithm"
             )
-    elif isinstance(addr, crypto.AddressScriptHash):
+    elif isinstance(addr, dcraddr.AddressScriptHash):
         scriptType = ScriptHashTy
     else:
         raise NotImplementedError(
@@ -1920,13 +1921,13 @@ def payToSStxChange(addr):
     # Only pay to pubkey hash and pay to script hash are
     # supported.
     scriptType = PubKeyHashTy
-    if isinstance(addr, crypto.AddressPubKeyHash):
+    if isinstance(addr, dcraddr.AddressPubKeyHash):
         if addr.sigType != crypto.STEcdsaSecp256k1:
             raise NotImplementedError(
                 "unable to generate payment script for "
                 "unsupported digital signature algorithm"
             )
-    elif isinstance(addr, crypto.AddressScriptHash):
+    elif isinstance(addr, dcraddr.AddressScriptHash):
         scriptType = ScriptHashTy
     else:
         raise NotImplementedError(
@@ -1949,9 +1950,9 @@ def decodeAddress(addr, netParams):
     decoded, netID = crypto.b58CheckDecode(addr)
 
     if netID == netParams.PubKeyAddrID:
-        return crypto.newAddressPubKey(decoded, netParams)
+        return dcraddr.newAddressPubKey(decoded, netParams)
     elif netID == netParams.PubKeyHashAddrID:
-        return crypto.newAddressPubKeyHash(decoded, netParams, crypto.STEcdsaSecp256k1)
+        return dcraddr.newAddressPubKeyHash(decoded, netParams, crypto.STEcdsaSecp256k1)
     elif netID == netParams.PKHEdwardsAddrID:
         # return NewAddressPubKeyHash(decoded, netParams, STEd25519)
         raise NotImplementedError("Edwards signatures not implemented")
@@ -1959,7 +1960,7 @@ def decodeAddress(addr, netParams):
         # return NewAddressPubKeyHash(decoded, netParams, STSchnorrSecp256k1)
         raise NotImplementedError("Schnorr signatures not implemented")
     elif netID == netParams.ScriptHashAddrID:
-        return crypto.newAddressScriptHashFromHash(decoded, netParams)
+        return dcraddr.newAddressScriptHashFromHash(decoded, netParams)
     raise NotImplementedError("unknown network ID %s" % netID)
 
 
@@ -2530,7 +2531,7 @@ def signP2PKHMsgTx(msgtx, prevOutputs, keysource, netParams):
         if len(addrs) != 1:
             continue
         apkh = addrs[0]
-        if not isinstance(apkh, crypto.AddressPubKeyHash):
+        if not isinstance(apkh, dcraddr.AddressPubKeyHash):
             raise DecredError("previous output address is not P2PKH")
 
         privKey = keysource.priv(apkh.string())
@@ -2638,7 +2639,7 @@ def pubKeyHashToAddrs(pkHash, netParams):
     passed hash to a pay-to-pubkey-hash address housed within an address
     list.  It is used to consolidate common code.
     """
-    return [crypto.newAddressPubKeyHash(pkHash, netParams, crypto.STEcdsaSecp256k1)]
+    return [dcraddr.newAddressPubKeyHash(pkHash, netParams, crypto.STEcdsaSecp256k1)]
 
 
 def scriptHashToAddrs(scriptHash, netParams):
@@ -2647,7 +2648,7 @@ def scriptHashToAddrs(scriptHash, netParams):
     hash to a pay-to-script-hash address housed within an address list.  It is
     used to consolidate common code.
     """
-    return [crypto.newAddressScriptHashFromHash(scriptHash, netParams)]
+    return [dcraddr.newAddressScriptHashFromHash(scriptHash, netParams)]
 
 
 def extractPkScriptAddrs(version, pkScript, netParams):
@@ -2677,14 +2678,14 @@ def extractPkScriptAddrs(version, pkScript, netParams):
     # Check for pay-to-alt-pubkey-hash script.
     data, sigType = extractPubKeyHashAltDetails(pkScript)
     if data:
-        addrs = [crypto.newAddressPubKeyHash(data, netParams, sigType)]
+        addrs = [dcraddr.newAddressPubKeyHash(data, netParams, sigType)]
         return PubkeyHashAltTy, addrs, 1
 
     # Check for pay-to-pubkey script.
     data = extractPubKey(pkScript)
     if data:
         pk = Curve.parsePubKey(data)
-        addrs = [crypto.AddressSecpPubKey(pk.serializeCompressed(), netParams)]
+        addrs = [dcraddr.AddressSecpPubKey(pk.serializeCompressed(), netParams)]
         return PubKeyTy, addrs, 1
 
     # Check for pay-to-alt-pubkey script.
@@ -2693,11 +2694,11 @@ def extractPkScriptAddrs(version, pkScript, netParams):
         raise NotImplementedError("only secp256k1 signatures are currently supported")
         # addrs = []
         # if sigType == dcrec.STEd25519:
-        #     addr = crypto.NewAddressEdwardsPubKey(pk, netParams)
+        #     addr = dcraddr.NewAddressEdwardsPubKey(pk, netParams)
         #     addrs.append(addr)
 
         # elif sigType == crypto.STSchnorrSecp256k1:
-        #     addr = crypto.NewAddressSecSchnorrPubKey(pk, netParams)
+        #     addr = dcraddr.NewAddressSecSchnorrPubKey(pk, netParams)
         #     addrs.append(addr)
 
         # return PubkeyAltTy, addrs, 1
@@ -2709,7 +2710,7 @@ def extractPkScriptAddrs(version, pkScript, netParams):
         addrs = []
         for encodedPK in details.pubKeys:
             pk = Curve.parsePubKey(encodedPK)
-            addrs.append(crypto.AddressSecpPubKey(pk.serializeCompressed(), netParams))
+            addrs.append(dcraddr.AddressSecpPubKey(pk.serializeCompressed(), netParams))
         return MultiSigTy, addrs, details.requiredSigs
 
     # Check for stake submission script.  Only stake-submission-tagged
@@ -3679,7 +3680,7 @@ def makeTicket(
 
     # Zero value P2PKH addr.
     zeroed = ByteArray(b"", length=20)
-    addrZeroed = crypto.newAddressPubKeyHash(zeroed, netParams, crypto.STEcdsaSecp256k1)
+    addrZeroed = dcraddr.newAddressPubKeyHash(zeroed, netParams, crypto.STEcdsaSecp256k1)
 
     # 2. Make an extra commitment to the pool.
     pkScript = generateSStxAddrPush(addrPool, amountsCommitted[0], limits)

--- a/decred/decred/dcr/vsp.py
+++ b/decred/decred/dcr/vsp.py
@@ -10,7 +10,7 @@ import time
 from urllib.parse import urlsplit, urlunsplit
 
 from decred import DecredError
-from decred.dcr import dcraddr
+from decred.dcr import addrlib
 from decred.util import encode, tinyhttp
 from decred.util.encode import ByteArray, unblobCheck
 
@@ -269,7 +269,7 @@ class VotingServiceProvider:
         """
         pi = self.purchaseInfo
         redeemScript = pi.script
-        scriptAddr = dcraddr.newAddressScriptHash(redeemScript, self.netParams)
+        scriptAddr = addrlib.AddressScriptHash.fromScript(redeemScript, self.netParams)
         if scriptAddr.string() != pi.ticketAddress:
             raise DecredError(
                 "ticket address mismatch. %s != %s"
@@ -282,7 +282,7 @@ class VotingServiceProvider:
         if numSigs != 1:
             raise DecredError("expected 2 required signatures, found 2")
         found = False
-        signAddr = txscript.decodeAddress(addr, self.netParams)
+        signAddr = addrlib.decodeAddress(addr, self.netParams)
         for addr in addrs:
             if addr.string() == signAddr.string():
                 found = True

--- a/decred/decred/dcr/vsp.py
+++ b/decred/decred/dcr/vsp.py
@@ -10,7 +10,7 @@ import time
 from urllib.parse import urlsplit, urlunsplit
 
 from decred import DecredError
-from decred.crypto import crypto
+from decred.dcr import dcraddr
 from decred.util import encode, tinyhttp
 from decred.util.encode import ByteArray, unblobCheck
 
@@ -269,7 +269,7 @@ class VotingServiceProvider:
         """
         pi = self.purchaseInfo
         redeemScript = pi.script
-        scriptAddr = crypto.newAddressScriptHash(redeemScript, self.netParams)
+        scriptAddr = dcraddr.newAddressScriptHash(redeemScript, self.netParams)
         if scriptAddr.string() != pi.ticketAddress:
             raise DecredError(
                 "ticket address mismatch. %s != %s"

--- a/decred/tests/integration/dcr/test_dcrdata_live.py
+++ b/decred/tests/integration/dcr/test_dcrdata_live.py
@@ -7,7 +7,7 @@ import time
 
 from decred.crypto import crypto, rando
 from decred.crypto.secp256k1 import curve as Curve
-from decred.dcr import account, dcrdata, txscript
+from decred.dcr import account, dcrdata, txscript, dcraddr
 from decred.dcr.nets import mainnet, testnet
 from decred.dcr.wire import msgtx
 from decred.util.encode import ByteArray
@@ -70,7 +70,7 @@ class TestDcrdata:
             def internal():
                 privKey = Curve.generateKey()
                 pkHash = crypto.hash160(privKey.pub.serializeCompressed().b)
-                addr = crypto.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
+                addr = dcraddr.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
                 addrs.append(addr)
                 keys[addr.string()] = privKey
                 return addr.string()
@@ -94,7 +94,7 @@ class TestDcrdata:
                     atoms = int(nextVal * 1e8)
                     privKey = Curve.generateKey()
                     pkHash = crypto.hash160(privKey.pub.serializeCompressed().b)
-                    addr = crypto.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
+                    addr = dcraddr.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
                     addrs.append(addr)
                     addrString = addr.string()
                     keys[addrString] = privKey
@@ -120,9 +120,9 @@ class TestDcrdata:
 
             poolPriv = Curve.generateKey()
             pkHash = crypto.hash160(poolPriv.pub.serializeCompressed().b)
-            poolAddr = crypto.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
+            poolAddr = dcraddr.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
             scriptHash = crypto.hash160("some script. doesn't matter".encode())
-            scriptAddr = crypto.AddressScriptHash(testnet.ScriptHashAddrID, scriptHash)
+            scriptAddr = dcraddr.AddressScriptHash(testnet.ScriptHashAddrID, scriptHash)
             ticketPrice = blockchain.stakeDiff()
 
             request = account.TicketRequest(

--- a/decred/tests/integration/dcr/test_dcrdata_live.py
+++ b/decred/tests/integration/dcr/test_dcrdata_live.py
@@ -7,7 +7,7 @@ import time
 
 from decred.crypto import crypto, rando
 from decred.crypto.secp256k1 import curve as Curve
-from decred.dcr import account, dcrdata, txscript, dcraddr
+from decred.dcr import account, addrlib, dcrdata, txscript
 from decred.dcr.nets import mainnet, testnet
 from decred.dcr.wire import msgtx
 from decred.util.encode import ByteArray
@@ -70,7 +70,7 @@ class TestDcrdata:
             def internal():
                 privKey = Curve.generateKey()
                 pkHash = crypto.hash160(privKey.pub.serializeCompressed().b)
-                addr = dcraddr.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
+                addr = addrlib.AddressPubKeyHash(pkHash, testnet)
                 addrs.append(addr)
                 keys[addr.string()] = privKey
                 return addr.string()
@@ -94,7 +94,7 @@ class TestDcrdata:
                     atoms = int(nextVal * 1e8)
                     privKey = Curve.generateKey()
                     pkHash = crypto.hash160(privKey.pub.serializeCompressed().b)
-                    addr = dcraddr.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
+                    addr = addrlib.AddressPubKeyHash(pkHash, testnet)
                     addrs.append(addr)
                     addrString = addr.string()
                     keys[addrString] = privKey
@@ -120,9 +120,9 @@ class TestDcrdata:
 
             poolPriv = Curve.generateKey()
             pkHash = crypto.hash160(poolPriv.pub.serializeCompressed().b)
-            poolAddr = dcraddr.AddressPubKeyHash(testnet.PubKeyHashAddrID, pkHash)
+            poolAddr = addrlib.AddressPubKeyHash(pkHash, testnet)
             scriptHash = crypto.hash160("some script. doesn't matter".encode())
-            scriptAddr = dcraddr.AddressScriptHash(testnet.ScriptHashAddrID, scriptHash)
+            scriptAddr = addrlib.AddressScriptHash(scriptHash, testnet)
             ticketPrice = blockchain.stakeDiff()
 
             request = account.TicketRequest(

--- a/decred/tests/integration/dcr/test_rpc.py
+++ b/decred/tests/integration/dcr/test_rpc.py
@@ -14,7 +14,7 @@ import pytest
 
 from decred import DecredError
 from decred.crypto import crypto, opcode
-from decred.dcr import account, rpc, txscript
+from decred.dcr import account, rpc, txscript, dcraddr
 from decred.dcr.nets import mainnet
 from decred.dcr.wire import wire
 from decred.dcr.wire.msgblock import BlockHeader
@@ -436,14 +436,14 @@ def test_Client(config):
         getRawTransaction.txOut[0].pkScript, opcode.OP_SSTX
     )
     if rawaddr:
-        addressWithTickets = crypto.AddressScriptHash(
+        addressWithTickets = dcraddr.AddressScriptHash(
             mainnet.ScriptHashAddrID, rawaddr
         ).string()
     else:
         rawaddr = txscript.extractStakePubKeyHash(
             getRawTransaction.txOut[0].pkScript, opcode.OP_SSTX
         )
-        addressWithTickets = crypto.AddressPubKeyHash(
+        addressWithTickets = dcraddr.AddressPubKeyHash(
             mainnet.PubKeyHashAddrID, rawaddr
         ).string()
 
@@ -515,7 +515,7 @@ def test_Client(config):
     amount = {cookedAddress2: amt + 1}
 
     zeroed = ByteArray(b"", length=20)
-    changeAddr = crypto.newAddressPubKeyHash(
+    changeAddr = dcraddr.newAddressPubKeyHash(
         zeroed, mainnet, crypto.STEcdsaSecp256k1
     ).string()
     # only the first argument for couts is a non-zero value
@@ -526,10 +526,10 @@ def test_Client(config):
     op = OutPoint(txHash=revocableTicket.hash(), idx=0, tree=wire.TxTreeStake)
     inputPool = txscript.ExtendedOutPoint(op=op, amt=1, pkScript=script,)
     inputMain = txscript.ExtendedOutPoint(op=op, amt=amt, pkScript=script,)
-    ticketAddr = crypto.newAddressScriptHashFromHash(
+    ticketAddr = dcraddr.newAddressScriptHashFromHash(
         ByteArray(b58decode(cookedAddress2)[2:-4]), mainnet
     )
-    mainAddr = crypto.newAddressScriptHashFromHash(
+    mainAddr = dcraddr.newAddressScriptHashFromHash(
         ByteArray(b58decode(mainnetAddress)[2:-4]), mainnet
     )
 

--- a/decred/tests/integration/dcr/test_rpc.py
+++ b/decred/tests/integration/dcr/test_rpc.py
@@ -14,7 +14,7 @@ import pytest
 
 from decred import DecredError
 from decred.crypto import crypto, opcode
-from decred.dcr import account, rpc, txscript, dcraddr
+from decred.dcr import account, addrlib, rpc, txscript
 from decred.dcr.nets import mainnet
 from decred.dcr.wire import wire
 from decred.dcr.wire.msgblock import BlockHeader
@@ -436,16 +436,12 @@ def test_Client(config):
         getRawTransaction.txOut[0].pkScript, opcode.OP_SSTX
     )
     if rawaddr:
-        addressWithTickets = dcraddr.AddressScriptHash(
-            mainnet.ScriptHashAddrID, rawaddr
-        ).string()
+        addressWithTickets = addrlib.AddressScriptHash(rawaddr, mainnet).string()
     else:
         rawaddr = txscript.extractStakePubKeyHash(
             getRawTransaction.txOut[0].pkScript, opcode.OP_SSTX
         )
-        addressWithTickets = dcraddr.AddressPubKeyHash(
-            mainnet.PubKeyHashAddrID, rawaddr
-        ).string()
+        addressWithTickets = addrlib.AddressPubKeyHash(rawaddr, mainnet).string()
 
     getRawTransaction = rpcClient.getRawTransaction(aTicket, 1)
     assert isinstance(getRawTransaction, rpc.RawTransactionResult)
@@ -515,7 +511,7 @@ def test_Client(config):
     amount = {cookedAddress2: amt + 1}
 
     zeroed = ByteArray(b"", length=20)
-    changeAddr = dcraddr.newAddressPubKeyHash(
+    changeAddr = addrlib.AddressPubKeyHash(
         zeroed, mainnet, crypto.STEcdsaSecp256k1
     ).string()
     # only the first argument for couts is a non-zero value
@@ -526,10 +522,10 @@ def test_Client(config):
     op = OutPoint(txHash=revocableTicket.hash(), idx=0, tree=wire.TxTreeStake)
     inputPool = txscript.ExtendedOutPoint(op=op, amt=1, pkScript=script,)
     inputMain = txscript.ExtendedOutPoint(op=op, amt=amt, pkScript=script,)
-    ticketAddr = dcraddr.newAddressScriptHashFromHash(
+    ticketAddr = addrlib.AddressScriptHash(
         ByteArray(b58decode(cookedAddress2)[2:-4]), mainnet
     )
-    mainAddr = dcraddr.newAddressScriptHashFromHash(
+    mainAddr = addrlib.AddressScriptHash(
         ByteArray(b58decode(mainnetAddress)[2:-4]), mainnet
     )
 

--- a/decred/tests/unit/crypto/test_crypto.py
+++ b/decred/tests/unit/crypto/test_crypto.py
@@ -8,8 +8,8 @@ import unittest
 import pytest
 
 from decred import DecredError
-from decred.dcr import dcraddr
 from decred.crypto import crypto, rando
+from decred.dcr import addrlib
 from decred.dcr.nets import mainnet
 from decred.util.encode import ByteArray
 
@@ -49,7 +49,7 @@ class TestCrypto(unittest.TestCase):
             ),
         ]
         for hexKey, addrStr, hash160 in data:
-            addr = dcraddr.AddressSecpPubKey(ByteArray(hexKey), mainnet)
+            addr = addrlib.AddressSecpPubKey(ByteArray(hexKey), mainnet)
             self.assertEqual(addr.string(), addrStr)
             self.assertEqual(addr.hash160().hex(), hash160)
 
@@ -78,7 +78,7 @@ class TestCrypto(unittest.TestCase):
         ]
         for pubkeyHash, addrStr in pairs:
             pubkeyHashBA = ByteArray(pubkeyHash)
-            addr = dcraddr.AddressPubKeyHash(mainnet.PubKeyHashAddrID, pubkeyHashBA)
+            addr = addrlib.AddressPubKeyHash(pubkeyHashBA, mainnet)
             self.assertEqual(addr.string(), addrStr)
             self.assertEqual(addr.scriptAddress(), pubkeyHashBA)
             self.assertEqual(addr.hash160(), pubkeyHashBA)
@@ -107,7 +107,7 @@ class TestCrypto(unittest.TestCase):
             ),
         ]
         for scriptHash, addrStr in pairs:
-            addr = dcraddr.newAddressScriptHashFromHash(ByteArray(scriptHash), mainnet)
+            addr = addrlib.AddressScriptHash(ByteArray(scriptHash), mainnet)
             self.assertEqual(addr.string(), addrStr)
 
     def test_extended_key(self):

--- a/decred/tests/unit/crypto/test_crypto.py
+++ b/decred/tests/unit/crypto/test_crypto.py
@@ -8,6 +8,7 @@ import unittest
 import pytest
 
 from decred import DecredError
+from decred.dcr import dcraddr
 from decred.crypto import crypto, rando
 from decred.dcr.nets import mainnet
 from decred.util.encode import ByteArray
@@ -48,7 +49,7 @@ class TestCrypto(unittest.TestCase):
             ),
         ]
         for hexKey, addrStr, hash160 in data:
-            addr = crypto.AddressSecpPubKey(ByteArray(hexKey), mainnet)
+            addr = dcraddr.AddressSecpPubKey(ByteArray(hexKey), mainnet)
             self.assertEqual(addr.string(), addrStr)
             self.assertEqual(addr.hash160().hex(), hash160)
 
@@ -77,7 +78,7 @@ class TestCrypto(unittest.TestCase):
         ]
         for pubkeyHash, addrStr in pairs:
             pubkeyHashBA = ByteArray(pubkeyHash)
-            addr = crypto.AddressPubKeyHash(mainnet.PubKeyHashAddrID, pubkeyHashBA)
+            addr = dcraddr.AddressPubKeyHash(mainnet.PubKeyHashAddrID, pubkeyHashBA)
             self.assertEqual(addr.string(), addrStr)
             self.assertEqual(addr.scriptAddress(), pubkeyHashBA)
             self.assertEqual(addr.hash160(), pubkeyHashBA)
@@ -106,7 +107,7 @@ class TestCrypto(unittest.TestCase):
             ),
         ]
         for scriptHash, addrStr in pairs:
-            addr = crypto.newAddressScriptHashFromHash(ByteArray(scriptHash), mainnet)
+            addr = dcraddr.newAddressScriptHashFromHash(ByteArray(scriptHash), mainnet)
             self.assertEqual(addr.string(), addrStr)
 
     def test_extended_key(self):

--- a/decred/tests/unit/dcr/test_account.py
+++ b/decred/tests/unit/dcr/test_account.py
@@ -9,7 +9,7 @@ import pytest
 
 from decred import DecredError
 from decred.crypto import crypto, opcode, rando
-from decred.dcr import account, nets, txscript
+from decred.dcr import account, nets, txscript, dcraddr
 from decred.dcr.vsp import PurchaseInfo, VotingServiceProvider
 from decred.dcr.wire import msgblock, msgtx
 from decred.util.database import KeyValueDatabase
@@ -666,7 +666,7 @@ class TestAccount:
         op = msgtx.TxOut(ticket.satoshis, ticket.scriptPubKey)
         ticketTx.addTxOut(op)
         ticket.tinfo.status = "missed"
-        redeemHash = crypto.AddressScriptHash(
+        redeemHash = dcraddr.AddressScriptHash(
             nets.mainnet.ScriptHashAddrID,
             txscript.extractStakeScriptHash(ticketScript, opcode.OP_SSTX),
         )
@@ -1058,7 +1058,7 @@ class TestAccount:
 
     def test_nextBranchAddress(self):
         class FakeExtendedKey:
-            def deriveChildAddress(self, i, netParams):
+            def child(self, i):
                 raise crypto.CrazyKeyError
 
         db = KeyValueDatabase(":memory:").child("tmp")

--- a/decred/tests/unit/dcr/test_account.py
+++ b/decred/tests/unit/dcr/test_account.py
@@ -9,7 +9,7 @@ import pytest
 
 from decred import DecredError
 from decred.crypto import crypto, opcode, rando
-from decred.dcr import account, nets, txscript, dcraddr
+from decred.dcr import account, addrlib, nets, txscript
 from decred.dcr.vsp import PurchaseInfo, VotingServiceProvider
 from decred.dcr.wire import msgblock, msgtx
 from decred.util.database import KeyValueDatabase
@@ -604,7 +604,7 @@ class TestAccount:
         newVal = int(5e8)
         expVal = acct.calcBalance().available + newVal
         addr = acct.externalAddresses[1]
-        a = txscript.decodeAddress(addr, nets.mainnet)
+        a = addrlib.decodeAddress(addr, nets.mainnet)
         script = txscript.payToAddrScript(a)
         newTx = msgtx.MsgTx.new()
         op = msgtx.TxOut(newVal, script)
@@ -620,7 +620,7 @@ class TestAccount:
         acct.stakePool().authorize = lambda a: True
         newVal = int(3e8)
         addr = acct.externalAddresses[2]
-        a = txscript.decodeAddress(addr, nets.mainnet)
+        a = addrlib.decodeAddress(addr, nets.mainnet)
         script = txscript.payToAddrScript(a)
         newTx = msgtx.MsgTx.new()
         op = msgtx.TxOut(newVal, script)
@@ -666,9 +666,8 @@ class TestAccount:
         op = msgtx.TxOut(ticket.satoshis, ticket.scriptPubKey)
         ticketTx.addTxOut(op)
         ticket.tinfo.status = "missed"
-        redeemHash = dcraddr.AddressScriptHash(
-            nets.mainnet.ScriptHashAddrID,
-            txscript.extractStakeScriptHash(ticketScript, opcode.OP_SSTX),
+        redeemHash = addrlib.AddressScriptHash(
+            txscript.extractStakeScriptHash(ticketScript, opcode.OP_SSTX), nets.mainnet,
         )
         acct.stakePool().purchaseInfo.ticketAddress = redeemHash.string()
         revoked = False

--- a/decred/tests/unit/dcr/test_addrlib.py
+++ b/decred/tests/unit/dcr/test_addrlib.py
@@ -1,0 +1,438 @@
+"""
+Copyright (c) 2019-2020, the Decred developers
+See LICENSE for details
+"""
+
+from base58 import b58decode
+
+from decred import DecredError
+from decred.crypto import crypto
+from decred.dcr import addrlib
+from decred.dcr.nets import mainnet, testnet
+from decred.util.encode import ByteArray
+
+
+def test_addresses():
+    class test:
+        def __init__(
+            self,
+            name="",
+            addr="",
+            saddr="",
+            encoded="",
+            valid=False,
+            scriptAddress=None,
+            f=None,
+            net=None,
+            skipComp=False,
+        ):
+            self.name = name
+            self.addr = addr
+            self.saddr = saddr
+            self.encoded = encoded
+            self.valid = valid
+            self.scriptAddress = scriptAddress
+            self.f = f
+            self.net = net
+            # Pubkey addresses are often printed as pkh addresses, making
+            # comparison of the decoded address impossible.
+            self.skipComp = skipComp
+
+    addrPKH = addrlib.AddressPubKeyHash
+    addrSH = addrlib.AddressScriptHash.fromScript
+    addrSHH = addrlib.AddressScriptHash
+    addrPK = addrlib.AddressSecpPubKey
+
+    tests = []
+    # Positive P2PKH tests.
+    tests.append(
+        test(
+            name="mainnet p2pkh",
+            addr="DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
+            encoded="DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
+            valid=True,
+            scriptAddress=ByteArray("2789d58cfa0957d206f025c2af056fc8a77cebb0"),
+            f=lambda: addrPKH(
+                ByteArray("2789d58cfa0957d206f025c2af056fc8a77cebb0"),
+                mainnet,
+                crypto.STEcdsaSecp256k1,
+            ),
+            net=mainnet,
+        )
+    )
+    tests.append(
+        test(
+            name="mainnet p2pkh 2",
+            addr="DsU7xcg53nxaKLLcAUSKyRndjG78Z2VZnX9",
+            encoded="DsU7xcg53nxaKLLcAUSKyRndjG78Z2VZnX9",
+            valid=True,
+            scriptAddress=ByteArray("229ebac30efd6a69eec9c1a48e048b7c975c25f2"),
+            f=lambda: addrPKH(
+                ByteArray("229ebac30efd6a69eec9c1a48e048b7c975c25f2"),
+                mainnet,
+                crypto.STEcdsaSecp256k1,
+            ),
+            net=mainnet,
+        )
+    )
+    tests.append(
+        test(
+            name="testnet p2pkh",
+            addr="Tso2MVTUeVrjHTBFedFhiyM7yVTbieqp91h",
+            encoded="Tso2MVTUeVrjHTBFedFhiyM7yVTbieqp91h",
+            valid=True,
+            scriptAddress=ByteArray("f15da1cb8d1bcb162c6ab446c95757a6e791c916"),
+            f=lambda: addrPKH(
+                ByteArray("f15da1cb8d1bcb162c6ab446c95757a6e791c916"),
+                testnet,
+                crypto.STEcdsaSecp256k1,
+            ),
+            net=testnet,
+        )
+    )
+
+    # Negative P2PKH tests.
+    tests.append(
+        test(
+            name="p2pkh wrong hash length",
+            addr="",
+            valid=False,
+            f=lambda: addrPKH(
+                ByteArray("000ef030107fd26e0b6bf40512bca2ceb1dd80adaa"),
+                mainnet,
+                crypto.STEcdsaSecp256k1,
+            ),
+        )
+    )
+    tests.append(
+        test(
+            name="p2pkh bad checksum",
+            addr="TsmWaPM77WSyA3aiQ2Q1KnwGDVWvEkhip23",
+            valid=False,
+            net=testnet,
+        )
+    )
+
+    # Positive P2SH tests.
+    tests.append(
+        test(
+            # Taken from transactions:
+            # output:
+            #   3c9018e8d5615c306d72397f8f5eef44308c98fb576a88e030c25456b4f3a7ac
+            # input:
+            #   837dea37ddc8b1e3ce646f1a656e79bbd8cc7f558ac56a169626d649ebe2a3ba.
+            name="mainnet p2sh",
+            addr="DcuQKx8BES9wU7C6Q5VmLBjw436r27hayjS",
+            encoded="DcuQKx8BES9wU7C6Q5VmLBjw436r27hayjS",
+            valid=True,
+            scriptAddress=ByteArray("f0b4e85100aee1a996f22915eb3c3f764d53779a"),
+            f=lambda: addrSH(
+                ByteArray(
+                    "512103aa43f0a6c15730d886cc1f0342046d2"
+                    "0175483d90d7ccb657f90c489111d794c51ae"
+                ),
+                mainnet,
+            ),
+            net=mainnet,
+        )
+    )
+    tests.append(
+        test(
+            # Taken from transactions:
+            # output:
+            #   b0539a45de13b3e0403909b8bd1a555b8cbe45fd4e3f3fda76f3a5f52835c29d
+            # input: (not yet redeemed at time test was written)
+            name="mainnet p2sh 2",
+            addr="DcqgK4N4Ccucu2Sq4VDAdu4wH4LASLhzLVp",
+            encoded="DcqgK4N4Ccucu2Sq4VDAdu4wH4LASLhzLVp",
+            valid=True,
+            scriptAddress=ByteArray("c7da5095683436f4435fc4e7163dcafda1a2d007"),
+            f=lambda: addrSHH(
+                ByteArray("c7da5095683436f4435fc4e7163dcafda1a2d007"), mainnet,
+            ),
+            net=mainnet,
+        )
+    )
+    tests.append(
+        test(
+            # Taken from bitcoind base58_keys_valid.
+            name="testnet p2sh",
+            addr="TccWLgcquqvwrfBocq5mcK5kBiyw8MvyvCi",
+            encoded="TccWLgcquqvwrfBocq5mcK5kBiyw8MvyvCi",
+            valid=True,
+            scriptAddress=ByteArray("36c1ca10a8a6a4b5d4204ac970853979903aa284"),
+            f=lambda: addrSHH(
+                ByteArray("36c1ca10a8a6a4b5d4204ac970853979903aa284"), testnet,
+            ),
+            net=testnet,
+        )
+    )
+
+    # Negative P2SH tests.
+    tests.append(
+        test(
+            name="p2sh wrong hash length",
+            addr="",
+            valid=False,
+            f=lambda: addrSHH(
+                ByteArray("00f815b036d9bbbce5e9f2a00abd1bf3dc91e95510"), mainnet,
+            ),
+            net=mainnet,
+        )
+    )
+
+    # Positive P2PK tests.
+    tests.append(
+        test(
+            name="mainnet p2pk compressed (0x02)",
+            addr="DsT4FDqBKYG1Xr8aGrT1rKP3kiv6TZ5K5th",
+            encoded="DsT4FDqBKYG1Xr8aGrT1rKP3kiv6TZ5K5th",
+            valid=True,
+            scriptAddress=ByteArray(
+                "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
+            ),
+            f=lambda: addrPK(
+                ByteArray(
+                    "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
+                ),
+                mainnet,
+            ),
+            net=mainnet,
+            skipComp=True,
+        )
+    )
+    tests.append(
+        test(
+            name="mainnet p2pk compressed (0x03)",
+            addr="DsfiE2y23CGwKNxSGjbfPGeEW4xw1tamZdc",
+            encoded="DsfiE2y23CGwKNxSGjbfPGeEW4xw1tamZdc",
+            valid=True,
+            scriptAddress=ByteArray(
+                "03e925aafc1edd44e7c7f1ea4fb7d265dc672f204c3d0c81930389c10b81fb75de"
+            ),
+            f=lambda: addrPK(
+                ByteArray(
+                    "03e925aafc1edd44e7c7f1ea4fb7d265dc672f204c3d0c81930389c10b81fb75de"
+                ),
+                mainnet,
+            ),
+            net=mainnet,
+            skipComp=True,
+        )
+    )
+    tests.append(
+        test(
+            name="mainnet p2pk uncompressed (0x04)",
+            addr="DkM3EyZ546GghVSkvzb6J47PvGDyntqiDtFgipQhNj78Xm2mUYRpf",
+            encoded="DsfFjaADsV8c5oHWx85ZqfxCZy74K8RFuhK",
+            valid=True,
+            saddr="0264c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b16374dace6778f0",
+            scriptAddress=ByteArray(
+                "0464c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b16374dace6778f"
+                "0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3e80808a1fa3203904"
+            ),
+            f=lambda: addrPK(
+                ByteArray(
+                    "0464c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b16374dace6778f"
+                    "0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3e80808a1fa3203904"
+                ),
+                mainnet,
+            ),
+            net=mainnet,
+        )
+    )
+    tests.append(
+        test(
+            name="testnet p2pk compressed (0x02)",
+            addr="Tso9sQD3ALqRsmEkAm7KvPrkGbeG2Vun7Kv",
+            encoded="Tso9sQD3ALqRsmEkAm7KvPrkGbeG2Vun7Kv",
+            valid=True,
+            scriptAddress=ByteArray(
+                "026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06e"
+            ),
+            f=lambda: addrPK(
+                ByteArray(
+                    "026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06e"
+                ),
+                testnet,
+            ),
+            net=testnet,
+            skipComp=True,
+        )
+    )
+    tests.append(
+        test(
+            name="testnet p2pk compressed (0x03)",
+            addr="TsWZ1EzypJfMwBKAEDYKuyHRGctqGAxMje2",
+            encoded="TsWZ1EzypJfMwBKAEDYKuyHRGctqGAxMje2",
+            valid=True,
+            scriptAddress=ByteArray(
+                "030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af5"
+            ),
+            f=lambda: addrPK(
+                ByteArray(
+                    "030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af5"
+                ),
+                testnet,
+            ),
+            net=testnet,
+            skipComp=True,
+        )
+    )
+    tests.append(
+        test(
+            name="testnet p2pk uncompressed (0x04)",
+            addr="TkKmMiY5iDh4U3KkSopYgkU1AzhAcQZiSoVhYhFymZHGMi9LM9Fdt",
+            encoded="Tso9sQD3ALqRsmEkAm7KvPrkGbeG2Vun7Kv",
+            valid=True,
+            saddr="026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06e",
+            scriptAddress=ByteArray(
+                "046a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06"
+                "ed548c8c16fb5eb9007cb94220b3bb89491d5a1fd2d77867fca64217acecf2244"
+            ),
+            f=lambda: addrPK(
+                ByteArray(
+                    "046a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06"
+                    "ed548c8c16fb5eb9007cb94220b3bb89491d5a1fd2d77867fca64217acecf2244"
+                ),
+                testnet,
+            ),
+            net=testnet,
+        )
+    )
+
+    # Negative P2PK tests.
+    tests.append(
+        test(
+            name="mainnet p2pk hybrid (0x06)",
+            addr="",
+            valid=False,
+            f=lambda: addrPK(
+                ByteArray(
+                    "0664c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b16374dace6778f"
+                    "0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3e80808a1fa3203904"
+                ),
+                mainnet,
+            ),
+            net=mainnet,
+        )
+    )
+    tests.append(
+        test(
+            name="mainnet p2pk hybrid (0x07)",
+            addr="",
+            valid=False,
+            f=lambda: addrPK(
+                ByteArray(
+                    "07348d8aeb4253ca52456fe5da94ab1263bfee16bb8192497f666389ca964f847"
+                    "98375129d7958843b14258b905dc94faed324dd8a9d67ffac8cc0a85be84bac5d"
+                ),
+                mainnet,
+            ),
+            net=mainnet,
+        )
+    )
+    tests.append(
+        test(
+            name="testnet p2pk hybrid (0x06)",
+            addr="",
+            valid=False,
+            f=lambda: addrPK(
+                ByteArray(
+                    "066a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06"
+                    "ed548c8c16fb5eb9007cb94220b3bb89491d5a1fd2d77867fca64217acecf2244"
+                ),
+                testnet,
+            ),
+            net=testnet,
+        )
+    )
+    tests.append(
+        test(
+            name="testnet p2pk hybrid (0x07)",
+            addr="",
+            valid=False,
+            f=lambda: addrPK(
+                ByteArray(
+                    "07edd40747de905a9becb14987a1a26c1adbd617c45e1583c142a635bfda9493d"
+                    "fa1c6d36735974965fe7b861e7f6fcc087dc7fe47380fa8bde0d9c322d53c0e89"
+                ),
+                testnet,
+            ),
+            net=testnet,
+        )
+    )
+
+    for test in tests:
+        # Decode addr and compare error against valid.
+        err = None
+        try:
+            decoded = addrlib.decodeAddress(test.addr, test.net)
+        except DecredError as e:
+            err = e
+        assert (err is None) == test.valid, f"{test.name} error: {err}"
+
+        if err is None:
+            # Ensure the stringer returns the same address as the original.
+            assert test.addr == decoded.string(), test.name
+
+            # Encode again and compare against the original.
+            encoded = decoded.address()
+            assert test.encoded == encoded
+
+            # Perform type-specific calculations.
+            if isinstance(decoded, addrlib.AddressPubKeyHash):
+                d = ByteArray(b58decode(encoded))
+                saddr = d[2 : 2 + crypto.RIPEMD160_SIZE]
+
+            elif isinstance(decoded, addrlib.AddressScriptHash):
+                d = ByteArray(b58decode(encoded))
+                saddr = d[2 : 2 + crypto.RIPEMD160_SIZE]
+
+            elif isinstance(decoded, addrlib.AddressSecpPubKey):
+                # Ignore the error here since the script
+                # address is checked below.
+                try:
+                    saddr = ByteArray(decoded.string())
+                except ValueError:
+                    saddr = test.saddr
+
+            else:
+                raise AssertionError(
+                    f"Decoded address is of unknown type {type(decoded)}"
+                )
+
+            # Check script address, as well as the Hash160 method for P2PKH and
+            # P2SH addresses.
+            assert saddr == decoded.scriptAddress(), test.name
+
+            if isinstance(decoded, addrlib.AddressPubKeyHash):
+                assert decoded.pkHash == saddr
+
+            if isinstance(decoded, addrlib.AddressScriptHash):
+                assert decoded.hash160() == saddr
+
+        if not test.valid:
+            # If address is invalid, but a creation function exists,
+            # verify that it raises a DecredError.
+            if test.f is not None:
+                try:
+                    test.f()
+                    raise AssertionError("invalid tests should raise exception")
+                except DecredError:
+                    pass
+            continue
+
+        # Valid test, compare address created with f against expected result.
+        addr = test.f()
+        assert addr != object()
+        if not test.skipComp:
+            assert decoded == addr, test.name
+            assert decoded == addr.string(), test.name
+            assert addr.string() == decoded, test.name
+        assert addr.scriptAddress() == test.scriptAddress, test.name
+
+        # Test blobbing
+        b = addrlib.Address.blob(addr)
+        reAddr = addrlib.Address.unblob(b)
+        assert addr == reAddr

--- a/decred/tests/unit/dcr/test_addrlib.py
+++ b/decred/tests/unit/dcr/test_addrlib.py
@@ -13,109 +13,86 @@ from decred.util.encode import ByteArray
 
 
 def test_addresses():
-    class test:
-        def __init__(
-            self,
-            name="",
-            addr="",
-            saddr="",
-            encoded="",
-            valid=False,
-            scriptAddress=None,
-            f=None,
-            net=None,
-            skipComp=False,
-        ):
-            self.name = name
-            self.addr = addr
-            self.saddr = saddr
-            self.encoded = encoded
-            self.valid = valid
-            self.scriptAddress = scriptAddress
-            self.f = f
-            self.net = net
-            # Pubkey addresses are often printed as pkh addresses, making
-            # comparison of the decoded address impossible.
-            self.skipComp = skipComp
-
     addrPKH = addrlib.AddressPubKeyHash
     addrSH = addrlib.AddressScriptHash.fromScript
     addrSHH = addrlib.AddressScriptHash
     addrPK = addrlib.AddressSecpPubKey
 
-    tests = []
-    # Positive P2PKH tests.
-    tests.append(
-        test(
+    """
+    name (str): A name for the test.
+    addr (str): The expected Address.string().
+    saddr (str): The expected Address.scriptAddress() after decoding.
+    encoded (str): The expected Address.address().
+    valid (bool): False if the make func is expected to raise an error.
+    scriptAddress (ByteArray): The expected Address.scriptAddress(), but for
+        the address made with make.
+    make (func -> str): A function to create a new Address.
+    net (module): The network parameters.
+    skipComp (bool): Skip string comparison of decoded address. For
+        AddressSecpPubKey, the encoded pubkey is unrecoverable from the
+        AddressSecpPubKey.address() string.
+    """
+    tests = [
+        # Positive P2PKH tests.
+        dict(
             name="mainnet p2pkh",
             addr="DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
             encoded="DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
             valid=True,
             scriptAddress=ByteArray("2789d58cfa0957d206f025c2af056fc8a77cebb0"),
-            f=lambda: addrPKH(
+            make=lambda: addrPKH(
                 ByteArray("2789d58cfa0957d206f025c2af056fc8a77cebb0"),
                 mainnet,
                 crypto.STEcdsaSecp256k1,
             ),
-            net=mainnet,
-        )
-    )
-    tests.append(
-        test(
+            netParams=mainnet,
+        ),
+        dict(
             name="mainnet p2pkh 2",
             addr="DsU7xcg53nxaKLLcAUSKyRndjG78Z2VZnX9",
             encoded="DsU7xcg53nxaKLLcAUSKyRndjG78Z2VZnX9",
             valid=True,
             scriptAddress=ByteArray("229ebac30efd6a69eec9c1a48e048b7c975c25f2"),
-            f=lambda: addrPKH(
+            make=lambda: addrPKH(
                 ByteArray("229ebac30efd6a69eec9c1a48e048b7c975c25f2"),
                 mainnet,
                 crypto.STEcdsaSecp256k1,
             ),
-            net=mainnet,
-        )
-    )
-    tests.append(
-        test(
+            netParams=mainnet,
+        ),
+        dict(
             name="testnet p2pkh",
             addr="Tso2MVTUeVrjHTBFedFhiyM7yVTbieqp91h",
             encoded="Tso2MVTUeVrjHTBFedFhiyM7yVTbieqp91h",
             valid=True,
             scriptAddress=ByteArray("f15da1cb8d1bcb162c6ab446c95757a6e791c916"),
-            f=lambda: addrPKH(
+            make=lambda: addrPKH(
                 ByteArray("f15da1cb8d1bcb162c6ab446c95757a6e791c916"),
                 testnet,
                 crypto.STEcdsaSecp256k1,
             ),
-            net=testnet,
-        )
-    )
-
-    # Negative P2PKH tests.
-    tests.append(
-        test(
+            netParams=testnet,
+        ),
+        # Negative P2PKH tests.
+        dict(
             name="p2pkh wrong hash length",
             addr="",
             valid=False,
-            f=lambda: addrPKH(
+            make=lambda: addrPKH(
                 ByteArray("000ef030107fd26e0b6bf40512bca2ceb1dd80adaa"),
                 mainnet,
                 crypto.STEcdsaSecp256k1,
             ),
-        )
-    )
-    tests.append(
-        test(
+            netParams=mainnet,
+        ),
+        dict(
             name="p2pkh bad checksum",
             addr="TsmWaPM77WSyA3aiQ2Q1KnwGDVWvEkhip23",
             valid=False,
-            net=testnet,
-        )
-    )
-
-    # Positive P2SH tests.
-    tests.append(
-        test(
+            netParams=testnet,
+        ),
+        # Positive P2SH tests.
+        dict(
             # Taken from transactions:
             # output:
             #   3c9018e8d5615c306d72397f8f5eef44308c98fb576a88e030c25456b4f3a7ac
@@ -126,18 +103,16 @@ def test_addresses():
             encoded="DcuQKx8BES9wU7C6Q5VmLBjw436r27hayjS",
             valid=True,
             scriptAddress=ByteArray("f0b4e85100aee1a996f22915eb3c3f764d53779a"),
-            f=lambda: addrSH(
+            make=lambda: addrSH(
                 ByteArray(
                     "512103aa43f0a6c15730d886cc1f0342046d2"
                     "0175483d90d7ccb657f90c489111d794c51ae"
                 ),
                 mainnet,
             ),
-            net=mainnet,
-        )
-    )
-    tests.append(
-        test(
+            netParams=mainnet,
+        ),
+        dict(
             # Taken from transactions:
             # output:
             #   b0539a45de13b3e0403909b8bd1a555b8cbe45fd4e3f3fda76f3a5f52835c29d
@@ -147,43 +122,35 @@ def test_addresses():
             encoded="DcqgK4N4Ccucu2Sq4VDAdu4wH4LASLhzLVp",
             valid=True,
             scriptAddress=ByteArray("c7da5095683436f4435fc4e7163dcafda1a2d007"),
-            f=lambda: addrSHH(
+            make=lambda: addrSHH(
                 ByteArray("c7da5095683436f4435fc4e7163dcafda1a2d007"), mainnet,
             ),
-            net=mainnet,
-        )
-    )
-    tests.append(
-        test(
+            netParams=mainnet,
+        ),
+        dict(
             # Taken from bitcoind base58_keys_valid.
             name="testnet p2sh",
             addr="TccWLgcquqvwrfBocq5mcK5kBiyw8MvyvCi",
             encoded="TccWLgcquqvwrfBocq5mcK5kBiyw8MvyvCi",
             valid=True,
             scriptAddress=ByteArray("36c1ca10a8a6a4b5d4204ac970853979903aa284"),
-            f=lambda: addrSHH(
+            make=lambda: addrSHH(
                 ByteArray("36c1ca10a8a6a4b5d4204ac970853979903aa284"), testnet,
             ),
-            net=testnet,
-        )
-    )
-
-    # Negative P2SH tests.
-    tests.append(
-        test(
+            netParams=testnet,
+        ),
+        # Negative P2SH tests.
+        dict(
             name="p2sh wrong hash length",
             addr="",
             valid=False,
-            f=lambda: addrSHH(
+            make=lambda: addrSHH(
                 ByteArray("00f815b036d9bbbce5e9f2a00abd1bf3dc91e95510"), mainnet,
             ),
-            net=mainnet,
-        )
-    )
-
-    # Positive P2PK tests.
-    tests.append(
-        test(
+            netParams=mainnet,
+        ),
+        # Positive P2PK tests.
+        dict(
             name="mainnet p2pk compressed (0x02)",
             addr="DsT4FDqBKYG1Xr8aGrT1rKP3kiv6TZ5K5th",
             encoded="DsT4FDqBKYG1Xr8aGrT1rKP3kiv6TZ5K5th",
@@ -191,18 +158,16 @@ def test_addresses():
             scriptAddress=ByteArray(
                 "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
             ),
-            f=lambda: addrPK(
+            make=lambda: addrPK(
                 ByteArray(
                     "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
                 ),
                 mainnet,
             ),
-            net=mainnet,
+            netParams=mainnet,
             skipComp=True,
-        )
-    )
-    tests.append(
-        test(
+        ),
+        dict(
             name="mainnet p2pk compressed (0x03)",
             addr="DsfiE2y23CGwKNxSGjbfPGeEW4xw1tamZdc",
             encoded="DsfiE2y23CGwKNxSGjbfPGeEW4xw1tamZdc",
@@ -210,18 +175,16 @@ def test_addresses():
             scriptAddress=ByteArray(
                 "03e925aafc1edd44e7c7f1ea4fb7d265dc672f204c3d0c81930389c10b81fb75de"
             ),
-            f=lambda: addrPK(
+            make=lambda: addrPK(
                 ByteArray(
                     "03e925aafc1edd44e7c7f1ea4fb7d265dc672f204c3d0c81930389c10b81fb75de"
                 ),
                 mainnet,
             ),
-            net=mainnet,
+            netParams=mainnet,
             skipComp=True,
-        )
-    )
-    tests.append(
-        test(
+        ),
+        dict(
             name="mainnet p2pk uncompressed (0x04)",
             addr="DkM3EyZ546GghVSkvzb6J47PvGDyntqiDtFgipQhNj78Xm2mUYRpf",
             encoded="DsfFjaADsV8c5oHWx85ZqfxCZy74K8RFuhK",
@@ -231,18 +194,16 @@ def test_addresses():
                 "0464c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b16374dace6778f"
                 "0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3e80808a1fa3203904"
             ),
-            f=lambda: addrPK(
+            make=lambda: addrPK(
                 ByteArray(
                     "0464c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b16374dace6778f"
                     "0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3e80808a1fa3203904"
                 ),
                 mainnet,
             ),
-            net=mainnet,
-        )
-    )
-    tests.append(
-        test(
+            netParams=mainnet,
+        ),
+        dict(
             name="testnet p2pk compressed (0x02)",
             addr="Tso9sQD3ALqRsmEkAm7KvPrkGbeG2Vun7Kv",
             encoded="Tso9sQD3ALqRsmEkAm7KvPrkGbeG2Vun7Kv",
@@ -250,18 +211,16 @@ def test_addresses():
             scriptAddress=ByteArray(
                 "026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06e"
             ),
-            f=lambda: addrPK(
+            make=lambda: addrPK(
                 ByteArray(
                     "026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06e"
                 ),
                 testnet,
             ),
-            net=testnet,
+            netParams=testnet,
             skipComp=True,
-        )
-    )
-    tests.append(
-        test(
+        ),
+        dict(
             name="testnet p2pk compressed (0x03)",
             addr="TsWZ1EzypJfMwBKAEDYKuyHRGctqGAxMje2",
             encoded="TsWZ1EzypJfMwBKAEDYKuyHRGctqGAxMje2",
@@ -269,18 +228,16 @@ def test_addresses():
             scriptAddress=ByteArray(
                 "030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af5"
             ),
-            f=lambda: addrPK(
+            make=lambda: addrPK(
                 ByteArray(
                     "030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af5"
                 ),
                 testnet,
             ),
-            net=testnet,
+            netParams=testnet,
             skipComp=True,
-        )
-    )
-    tests.append(
-        test(
+        ),
+        dict(
             name="testnet p2pk uncompressed (0x04)",
             addr="TkKmMiY5iDh4U3KkSopYgkU1AzhAcQZiSoVhYhFymZHGMi9LM9Fdt",
             encoded="Tso9sQD3ALqRsmEkAm7KvPrkGbeG2Vun7Kv",
@@ -290,95 +247,87 @@ def test_addresses():
                 "046a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06"
                 "ed548c8c16fb5eb9007cb94220b3bb89491d5a1fd2d77867fca64217acecf2244"
             ),
-            f=lambda: addrPK(
+            make=lambda: addrPK(
                 ByteArray(
                     "046a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06"
                     "ed548c8c16fb5eb9007cb94220b3bb89491d5a1fd2d77867fca64217acecf2244"
                 ),
                 testnet,
             ),
-            net=testnet,
-        )
-    )
-
-    # Negative P2PK tests.
-    tests.append(
-        test(
+            netParams=testnet,
+        ),
+        # Negative P2PK tests.
+        dict(
             name="mainnet p2pk hybrid (0x06)",
             addr="",
             valid=False,
-            f=lambda: addrPK(
+            make=lambda: addrPK(
                 ByteArray(
                     "0664c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b16374dace6778f"
                     "0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3e80808a1fa3203904"
                 ),
                 mainnet,
             ),
-            net=mainnet,
-        )
-    )
-    tests.append(
-        test(
+            netParams=mainnet,
+        ),
+        dict(
             name="mainnet p2pk hybrid (0x07)",
             addr="",
             valid=False,
-            f=lambda: addrPK(
+            make=lambda: addrPK(
                 ByteArray(
                     "07348d8aeb4253ca52456fe5da94ab1263bfee16bb8192497f666389ca964f847"
                     "98375129d7958843b14258b905dc94faed324dd8a9d67ffac8cc0a85be84bac5d"
                 ),
                 mainnet,
             ),
-            net=mainnet,
-        )
-    )
-    tests.append(
-        test(
+            netParams=mainnet,
+        ),
+        dict(
             name="testnet p2pk hybrid (0x06)",
             addr="",
             valid=False,
-            f=lambda: addrPK(
+            make=lambda: addrPK(
                 ByteArray(
                     "066a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06"
                     "ed548c8c16fb5eb9007cb94220b3bb89491d5a1fd2d77867fca64217acecf2244"
                 ),
                 testnet,
             ),
-            net=testnet,
-        )
-    )
-    tests.append(
-        test(
+            netParams=testnet,
+        ),
+        dict(
             name="testnet p2pk hybrid (0x07)",
             addr="",
             valid=False,
-            f=lambda: addrPK(
+            make=lambda: addrPK(
                 ByteArray(
                     "07edd40747de905a9becb14987a1a26c1adbd617c45e1583c142a635bfda9493d"
                     "fa1c6d36735974965fe7b861e7f6fcc087dc7fe47380fa8bde0d9c322d53c0e89"
                 ),
                 testnet,
             ),
-            net=testnet,
-        )
-    )
+            netParams=testnet,
+        ),
+    ]
 
     for test in tests:
         # Decode addr and compare error against valid.
         err = None
+        name = test.get("name")
         try:
-            decoded = addrlib.decodeAddress(test.addr, test.net)
+            decoded = addrlib.decodeAddress(test["addr"], test["netParams"])
         except DecredError as e:
             err = e
-        assert (err is None) == test.valid, f"{test.name} error: {err}"
+        assert (err is None) == test["valid"], f"{name} error: {err}"
 
         if err is None:
             # Ensure the stringer returns the same address as the original.
-            assert test.addr == decoded.string(), test.name
+            assert test["addr"] == decoded.string(), name
 
             # Encode again and compare against the original.
             encoded = decoded.address()
-            assert test.encoded == encoded
+            assert test["encoded"] == encoded
 
             # Perform type-specific calculations.
             if isinstance(decoded, addrlib.AddressPubKeyHash):
@@ -395,7 +344,7 @@ def test_addresses():
                 try:
                     saddr = ByteArray(decoded.string())
                 except ValueError:
-                    saddr = test.saddr
+                    saddr = test["saddr"]
 
             else:
                 raise AssertionError(
@@ -404,7 +353,7 @@ def test_addresses():
 
             # Check script address, as well as the Hash160 method for P2PKH and
             # P2SH addresses.
-            assert saddr == decoded.scriptAddress(), test.name
+            assert saddr == decoded.scriptAddress(), name
 
             if isinstance(decoded, addrlib.AddressPubKeyHash):
                 assert decoded.pkHash == saddr
@@ -412,25 +361,26 @@ def test_addresses():
             if isinstance(decoded, addrlib.AddressScriptHash):
                 assert decoded.hash160() == saddr
 
-        if not test.valid:
+        make = test.get("make")
+        if not test["valid"]:
             # If address is invalid, but a creation function exists,
             # verify that it raises a DecredError.
-            if test.f is not None:
+            if make:
                 try:
-                    test.f()
+                    make()
                     raise AssertionError("invalid tests should raise exception")
                 except DecredError:
                     pass
             continue
 
         # Valid test, compare address created with f against expected result.
-        addr = test.f()
+        addr = make()
         assert addr != object()
-        if not test.skipComp:
-            assert decoded == addr, test.name
-            assert decoded == addr.string(), test.name
-            assert addr.string() == decoded, test.name
-        assert addr.scriptAddress() == test.scriptAddress, test.name
+        if not test.get("skipComp"):
+            assert decoded == addr, name
+            assert decoded == addr.string(), name
+            assert addr.string() == decoded, name
+        assert addr.scriptAddress() == test["scriptAddress"], name
 
         # Test blobbing
         b = addrlib.Address.blob(addr)

--- a/decred/tests/unit/dcr/test_txscript.py
+++ b/decred/tests/unit/dcr/test_txscript.py
@@ -13,7 +13,7 @@ import pytest
 from decred import DecredError
 from decred.crypto import crypto, opcode, rando
 from decred.crypto.secp256k1 import curve as Curve
-from decred.dcr import txscript
+from decred.dcr import txscript, dcraddr
 from decred.dcr.calc import SubsidyCache
 from decred.dcr.nets import mainnet, testnet
 from decred.dcr.wire import msgtx, wire
@@ -1921,7 +1921,7 @@ class TestTxScript(unittest.TestCase):
                             "test for signature suite %d not implemented" % suite
                         )
 
-                    address = crypto.newAddressPubKeyHash(
+                    address = dcraddr.newAddressPubKeyHash(
                         crypto.hash160(pkBytes.bytes()), testingParams, suite
                     )
 
@@ -1999,7 +1999,7 @@ class TestTxScript(unittest.TestCase):
                             "test for signature suite %d not implemented" % suite
                         )
 
-                    address = crypto.newAddressPubKeyHash(
+                    address = dcraddr.newAddressPubKeyHash(
                         crypto.hash160(pkBytes.bytes()), testingParams, suite
                     )
 
@@ -2075,7 +2075,7 @@ class TestTxScript(unittest.TestCase):
                             "test for signature suite %d not implemented" % suite
                         )
 
-                    address = crypto.newAddressPubKeyHash(
+                    address = dcraddr.newAddressPubKeyHash(
                         crypto.hash160(pkBytes.bytes()), testingParams, suite
                     )
 
@@ -2170,13 +2170,13 @@ class TestTxScript(unittest.TestCase):
                             "test for signature suite %d not implemented" % suite
                         )
 
-                    address = crypto.AddressSecpPubKey(pkBytes.bytes(), testingParams)
+                    address = dcraddr.AddressSecpPubKey(pkBytes.bytes(), testingParams)
 
-                    address2 = crypto.AddressSecpPubKey(pkBytes2.bytes(), testingParams)
+                    address2 = dcraddr.AddressSecpPubKey(pkBytes2.bytes(), testingParams)
 
                     pkScript = txscript.multiSigScript([address, address2], 2)
 
-                    scriptAddr = crypto.newAddressScriptHash(pkScript, testingParams)
+                    scriptAddr = dcraddr.newAddressScriptHash(pkScript, testingParams)
 
                     scriptPkScript = txscript.payToAddrScript(scriptAddr)
 
@@ -2225,7 +2225,7 @@ class TestTxScript(unittest.TestCase):
 
         privKey = Curve.generateKey()
         pkHash = crypto.hash160(privKey.pub.serializeCompressed().b)
-        addr = crypto.AddressPubKeyHash(mainnet.PubKeyHashAddrID, pkHash)
+        addr = dcraddr.AddressPubKeyHash(mainnet.PubKeyHashAddrID, pkHash)
 
         class keysource:
             @staticmethod
@@ -2268,10 +2268,10 @@ class TestTxScript(unittest.TestCase):
                 self.f = f
                 self.net = net
 
-        addrPKH = crypto.newAddressPubKeyHash
-        addrSH = crypto.newAddressScriptHash
-        addrSHH = crypto.newAddressScriptHashFromHash
-        addrPK = crypto.AddressSecpPubKey
+        addrPKH = dcraddr.newAddressPubKeyHash
+        addrSH = dcraddr.newAddressScriptHash
+        addrSHH = dcraddr.newAddressScriptHashFromHash
+        addrPK = dcraddr.AddressSecpPubKey
 
         tests = []
         # Positive P2PKH tests.
@@ -2607,15 +2607,15 @@ class TestTxScript(unittest.TestCase):
                 self.assertEqual(test.encoded, encoded)
 
                 # Perform type-specific calculations.
-                if isinstance(decoded, crypto.AddressPubKeyHash):
+                if isinstance(decoded, dcraddr.AddressPubKeyHash):
                     d = ByteArray(b58decode(encoded))
                     saddr = d[2 : 2 + crypto.RIPEMD160_SIZE]
 
-                elif isinstance(decoded, crypto.AddressScriptHash):
+                elif isinstance(decoded, dcraddr.AddressScriptHash):
                     d = ByteArray(b58decode(encoded))
                     saddr = d[2 : 2 + crypto.RIPEMD160_SIZE]
 
-                elif isinstance(decoded, crypto.AddressSecpPubKey):
+                elif isinstance(decoded, dcraddr.AddressSecpPubKey):
                     # Ignore the error here since the script
                     # address is checked below.
                     try:
@@ -2623,13 +2623,13 @@ class TestTxScript(unittest.TestCase):
                     except ValueError:
                         saddr = test.saddr
 
-                elif isinstance(decoded, crypto.AddressEdwardsPubKey):
+                elif isinstance(decoded, dcraddr.AddressEdwardsPubKey):
                     # Ignore the error here since the script
                     # address is checked below.
                     # saddr = ByteArray(decoded.String())
                     self.fail("Edwards sigs unsupported")
 
-                elif isinstance(decoded, crypto.AddressSecSchnorrPubKey):
+                elif isinstance(decoded, dcraddr.AddressSecSchnorrPubKey):
                     # Ignore the error here since the script
                     # address is checked below.
                     # saddr = ByteArray(decoded.String())
@@ -2639,10 +2639,10 @@ class TestTxScript(unittest.TestCase):
                 # P2SH addresses.
                 self.assertEqual(saddr, decoded.scriptAddress(), test.name)
 
-                if isinstance(decoded, crypto.AddressPubKeyHash):
+                if isinstance(decoded, dcraddr.AddressPubKeyHash):
                     self.assertEqual(decoded.pkHash, saddr)
 
-                if isinstance(decoded, crypto.AddressScriptHash):
+                if isinstance(decoded, dcraddr.AddressScriptHash):
                     self.assertEqual(decoded.hash160(), saddr)
 
             if not test.valid:
@@ -2674,7 +2674,7 @@ class TestTxScript(unittest.TestCase):
         scriptVersion = 0
 
         def pkAddr(b):
-            addr = crypto.AddressSecpPubKey(b, mainnet)
+            addr = dcraddr.AddressSecpPubKey(b, mainnet)
             # force the format to compressed, as per golang tests.
             addr.pubkeyFormat = crypto.PKFCompressed
             return addr
@@ -2682,7 +2682,7 @@ class TestTxScript(unittest.TestCase):
         """
         name (str): Short description of the test.
         script (ByteArray): The script to test.
-        addrs (list(crypto.AddressSecpPubKey)): Expected returned addresses.
+        addrs (list(dcraddr.AddressSecpPubKey)): Expected returned addresses.
         reqSigs (int): Expected returned required signatures.
         scriptClass (int): expected returned signature class.
         exception (Exception): The expected exception if present.
@@ -2756,7 +2756,7 @@ class TestTxScript(unittest.TestCase):
                 name="standard p2pkh",
                 script=ByteArray("76a914ad06dd6ddee55cbca9a9e3713bd7587509a3056488ac"),
                 addrs=[
-                    crypto.newAddressPubKeyHash(
+                    dcraddr.newAddressPubKeyHash(
                         ByteArray("ad06dd6ddee55cbca9a9e3713bd7587509a30564"),
                         mainnet,
                         crypto.STEcdsaSecp256k1,
@@ -2769,7 +2769,7 @@ class TestTxScript(unittest.TestCase):
                 name="standard p2sh",
                 script=ByteArray("a91463bcc565f9e68ee0189dd5cc67f1b0e5f02f45cb87"),
                 addrs=[
-                    crypto.newAddressScriptHashFromHash(
+                    dcraddr.newAddressScriptHashFromHash(
                         ByteArray("63bcc565f9e68ee0189dd5cc67f1b0e5f02f45cb"), mainnet
                     )
                 ],
@@ -2971,7 +2971,7 @@ class TestTxScript(unittest.TestCase):
         the correct scripts for the various types of addresses.
         """
         # 1MirQ9bwyQcGVJPwKUgapu5ouK2E2Ey4gX
-        p2pkhMain = crypto.newAddressPubKeyHash(
+        p2pkhMain = dcraddr.newAddressPubKeyHash(
             ByteArray("e34cce70c86373273efcc54ce7d2a491bb4a0e84"),
             mainnet,
             crypto.STEcdsaSecp256k1,
@@ -2979,24 +2979,24 @@ class TestTxScript(unittest.TestCase):
 
         # Taken from transaction:
         # b0539a45de13b3e0403909b8bd1a555b8cbe45fd4e3f3fda76f3a5f52835c29d
-        p2shMain = crypto.newAddressScriptHashFromHash(
+        p2shMain = dcraddr.newAddressScriptHashFromHash(
             ByteArray("e8c300c87986efa84c37c0519929019ef86eb5b4"), mainnet
         )
 
         # # disabled until Schnorr signatures implemented
         # # mainnet p2pk 13CG6SJ3yHUXo4Cr2RY4THLLJrNFuG3gUg
-        # p2pkCompressedMain = crypto.newAddressPubKey(ByteArray(
+        # p2pkCompressedMain = dcraddr.newAddressPubKey(ByteArray(
         #     "02192d74d0cb94344c9569c2e77901573d8d7903c3ebec3a957724895dca52c6b4"),
         #     mainnet)
 
-        p2pkCompressed2Main = crypto.AddressSecpPubKey(
+        p2pkCompressed2Main = dcraddr.AddressSecpPubKey(
             ByteArray(
                 "03b0bd634234abbb1ba1e986e884185c61cf43e001f9137f23c2c409273eb16e65"
             ),
             mainnet,
         )
 
-        p2pkUncompressedMain = crypto.AddressSecpPubKey(
+        p2pkUncompressedMain = dcraddr.AddressSecpPubKey(
             ByteArray(
                 "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5"
                 "cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3"
@@ -3007,7 +3007,7 @@ class TestTxScript(unittest.TestCase):
         # dcrd/tscript/standard_test.go
         p2pkUncompressedMain.pubkeyFormat = crypto.PKFCompressed
 
-        class BogusAddress(crypto.AddressPubKeyHash):
+        class BogusAddress(dcraddr.AddressPubKeyHash):
             pass
 
         bogusAddress = (
@@ -3537,16 +3537,16 @@ def test_merge_scripts():
     privKey1 = root.child(0).privateKey().key
     privKey2 = root.child(1).privateKey().key
     privKey3 = root.child(2).privateKey().key
-    pub1 = crypto.AddressSecpPubKey(
+    pub1 = dcraddr.AddressSecpPubKey(
         root.child(0).publicKey().serializeCompressed(), testnet
     )
-    pub2 = crypto.AddressSecpPubKey(
+    pub2 = dcraddr.AddressSecpPubKey(
         root.child(1).publicKey().serializeCompressed(), testnet
     )
-    pub3 = crypto.AddressSecpPubKey(
+    pub3 = dcraddr.AddressSecpPubKey(
         root.child(2).publicKey().serializeCompressed(), testnet
     )
-    pub4 = crypto.AddressSecpPubKey(
+    pub4 = dcraddr.AddressSecpPubKey(
         root.child(3).publicKey().serializeCompressed(), testnet
     )
     # P2PKH is a valid pay to public key hash script.

--- a/decred/tests/unit/dcr/test_txscript.py
+++ b/decred/tests/unit/dcr/test_txscript.py
@@ -7,13 +7,12 @@ import json
 import os
 import unittest
 
-from base58 import b58decode
 import pytest
 
 from decred import DecredError
 from decred.crypto import crypto, opcode, rando
 from decred.crypto.secp256k1 import curve as Curve
-from decred.dcr import txscript, dcraddr
+from decred.dcr import addrlib, txscript
 from decred.dcr.calc import SubsidyCache
 from decred.dcr.nets import mainnet, testnet
 from decred.dcr.wire import msgtx, wire
@@ -873,7 +872,7 @@ class TestTxScript(unittest.TestCase):
             )
         )
         for t in tests:
-            addr = txscript.decodeAddress(t.addrStr, t.net)
+            addr = addrlib.decodeAddress(t.addrStr, t.net)
             s = txscript.generateSStxAddrPush(addr, t.amount, t.limits)
             self.assertEqual(s, t.expected)
 
@@ -1921,7 +1920,7 @@ class TestTxScript(unittest.TestCase):
                             "test for signature suite %d not implemented" % suite
                         )
 
-                    address = dcraddr.newAddressPubKeyHash(
+                    address = addrlib.AddressPubKeyHash(
                         crypto.hash160(pkBytes.bytes()), testingParams, suite
                     )
 
@@ -1999,7 +1998,7 @@ class TestTxScript(unittest.TestCase):
                             "test for signature suite %d not implemented" % suite
                         )
 
-                    address = dcraddr.newAddressPubKeyHash(
+                    address = addrlib.AddressPubKeyHash(
                         crypto.hash160(pkBytes.bytes()), testingParams, suite
                     )
 
@@ -2075,12 +2074,12 @@ class TestTxScript(unittest.TestCase):
                             "test for signature suite %d not implemented" % suite
                         )
 
-                    address = dcraddr.newAddressPubKeyHash(
+                    address = addrlib.AddressPubKeyHash(
                         crypto.hash160(pkBytes.bytes()), testingParams, suite
                     )
 
                     pkScript = txscript.payToSSRtxPKHDirect(
-                        txscript.decodeAddress(
+                        addrlib.decodeAddress(
                             address.string(), testingParams
                         ).scriptAddress()
                     )
@@ -2170,13 +2169,17 @@ class TestTxScript(unittest.TestCase):
                             "test for signature suite %d not implemented" % suite
                         )
 
-                    address = dcraddr.AddressSecpPubKey(pkBytes.bytes(), testingParams)
+                    address = addrlib.AddressSecpPubKey(pkBytes.bytes(), testingParams)
 
-                    address2 = dcraddr.AddressSecpPubKey(pkBytes2.bytes(), testingParams)
+                    address2 = addrlib.AddressSecpPubKey(
+                        pkBytes2.bytes(), testingParams
+                    )
 
                     pkScript = txscript.multiSigScript([address, address2], 2)
 
-                    scriptAddr = dcraddr.newAddressScriptHash(pkScript, testingParams)
+                    scriptAddr = addrlib.AddressScriptHash.fromScript(
+                        pkScript, testingParams
+                    )
 
                     scriptPkScript = txscript.payToAddrScript(scriptAddr)
 
@@ -2225,7 +2228,7 @@ class TestTxScript(unittest.TestCase):
 
         privKey = Curve.generateKey()
         pkHash = crypto.hash160(privKey.pub.serializeCompressed().b)
-        addr = dcraddr.AddressPubKeyHash(mainnet.PubKeyHashAddrID, pkHash)
+        addr = addrlib.AddressPubKeyHash(pkHash, mainnet)
 
         class keysource:
             @staticmethod
@@ -2246,435 +2249,11 @@ class TestTxScript(unittest.TestCase):
                 crypto.STEcdsaSecp256k1,
             )
 
-    def test_addresses(self):
-        class test:
-            def __init__(
-                self,
-                name="",
-                addr="",
-                saddr="",
-                encoded="",
-                valid=False,
-                scriptAddress=None,
-                f=None,
-                net=None,
-            ):
-                self.name = name
-                self.addr = addr
-                self.saddr = saddr
-                self.encoded = encoded
-                self.valid = valid
-                self.scriptAddress = scriptAddress
-                self.f = f
-                self.net = net
-
-        addrPKH = dcraddr.newAddressPubKeyHash
-        addrSH = dcraddr.newAddressScriptHash
-        addrSHH = dcraddr.newAddressScriptHashFromHash
-        addrPK = dcraddr.AddressSecpPubKey
-
-        tests = []
-        # Positive P2PKH tests.
-        tests.append(
-            test(
-                name="mainnet p2pkh",
-                addr="DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
-                encoded="DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
-                valid=True,
-                scriptAddress=ByteArray("2789d58cfa0957d206f025c2af056fc8a77cebb0"),
-                f=lambda: addrPKH(
-                    ByteArray("2789d58cfa0957d206f025c2af056fc8a77cebb0"),
-                    mainnet,
-                    crypto.STEcdsaSecp256k1,
-                ),
-                net=mainnet,
-            )
-        )
-        tests.append(
-            test(
-                name="mainnet p2pkh 2",
-                addr="DsU7xcg53nxaKLLcAUSKyRndjG78Z2VZnX9",
-                encoded="DsU7xcg53nxaKLLcAUSKyRndjG78Z2VZnX9",
-                valid=True,
-                scriptAddress=ByteArray("229ebac30efd6a69eec9c1a48e048b7c975c25f2"),
-                f=lambda: addrPKH(
-                    ByteArray("229ebac30efd6a69eec9c1a48e048b7c975c25f2"),
-                    mainnet,
-                    crypto.STEcdsaSecp256k1,
-                ),
-                net=mainnet,
-            )
-        )
-        tests.append(
-            test(
-                name="testnet p2pkh",
-                addr="Tso2MVTUeVrjHTBFedFhiyM7yVTbieqp91h",
-                encoded="Tso2MVTUeVrjHTBFedFhiyM7yVTbieqp91h",
-                valid=True,
-                scriptAddress=ByteArray("f15da1cb8d1bcb162c6ab446c95757a6e791c916"),
-                f=lambda: addrPKH(
-                    ByteArray("f15da1cb8d1bcb162c6ab446c95757a6e791c916"),
-                    testnet,
-                    crypto.STEcdsaSecp256k1,
-                ),
-                net=testnet,
-            )
-        )
-
-        # Negative P2PKH tests.
-        tests.append(
-            test(
-                name="p2pkh wrong hash length",
-                addr="",
-                valid=False,
-                f=lambda: addrPKH(
-                    ByteArray("000ef030107fd26e0b6bf40512bca2ceb1dd80adaa"),
-                    mainnet,
-                    crypto.STEcdsaSecp256k1,
-                ),
-            )
-        )
-        tests.append(
-            test(
-                name="p2pkh bad checksum",
-                addr="TsmWaPM77WSyA3aiQ2Q1KnwGDVWvEkhip23",
-                valid=False,
-                net=testnet,
-            )
-        )
-
-        # Positive P2SH tests.
-        tests.append(
-            test(
-                # Taken from transactions:
-                # output:
-                #   3c9018e8d5615c306d72397f8f5eef44308c98fb576a88e030c25456b4f3a7ac
-                # input:
-                #   837dea37ddc8b1e3ce646f1a656e79bbd8cc7f558ac56a169626d649ebe2a3ba.
-                name="mainnet p2sh",
-                addr="DcuQKx8BES9wU7C6Q5VmLBjw436r27hayjS",
-                encoded="DcuQKx8BES9wU7C6Q5VmLBjw436r27hayjS",
-                valid=True,
-                scriptAddress=ByteArray("f0b4e85100aee1a996f22915eb3c3f764d53779a"),
-                f=lambda: addrSH(
-                    ByteArray(
-                        "512103aa43f0a6c15730d886cc1f0342046d2"
-                        "0175483d90d7ccb657f90c489111d794c51ae"
-                    ),
-                    mainnet,
-                ),
-                net=mainnet,
-            )
-        )
-        tests.append(
-            test(
-                # Taken from transactions:
-                # output:
-                #   b0539a45de13b3e0403909b8bd1a555b8cbe45fd4e3f3fda76f3a5f52835c29d
-                # input: (not yet redeemed at time test was written)
-                name="mainnet p2sh 2",
-                addr="DcqgK4N4Ccucu2Sq4VDAdu4wH4LASLhzLVp",
-                encoded="DcqgK4N4Ccucu2Sq4VDAdu4wH4LASLhzLVp",
-                valid=True,
-                scriptAddress=ByteArray("c7da5095683436f4435fc4e7163dcafda1a2d007"),
-                f=lambda: addrSHH(
-                    ByteArray("c7da5095683436f4435fc4e7163dcafda1a2d007"), mainnet,
-                ),
-                net=mainnet,
-            )
-        )
-        tests.append(
-            test(
-                # Taken from bitcoind base58_keys_valid.
-                name="testnet p2sh",
-                addr="TccWLgcquqvwrfBocq5mcK5kBiyw8MvyvCi",
-                encoded="TccWLgcquqvwrfBocq5mcK5kBiyw8MvyvCi",
-                valid=True,
-                scriptAddress=ByteArray("36c1ca10a8a6a4b5d4204ac970853979903aa284"),
-                f=lambda: addrSHH(
-                    ByteArray("36c1ca10a8a6a4b5d4204ac970853979903aa284"), testnet,
-                ),
-                net=testnet,
-            )
-        )
-
-        # Negative P2SH tests.
-        tests.append(
-            test(
-                name="p2sh wrong hash length",
-                addr="",
-                valid=False,
-                f=lambda: addrSHH(
-                    ByteArray("00f815b036d9bbbce5e9f2a00abd1bf3dc91e95510"), mainnet,
-                ),
-                net=mainnet,
-            )
-        )
-
-        # Positive P2PK tests.
-        tests.append(
-            test(
-                name="mainnet p2pk compressed (0x02)",
-                addr="DsT4FDqBKYG1Xr8aGrT1rKP3kiv6TZ5K5th",
-                encoded="DsT4FDqBKYG1Xr8aGrT1rKP3kiv6TZ5K5th",
-                valid=True,
-                scriptAddress=ByteArray(
-                    "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
-                ),
-                f=lambda: addrPK(
-                    ByteArray(
-                        "028f53838b7639563f27c94845549a41e5146bcd52e7fef0ea6da143a02b0fe2ed"
-                    ),
-                    mainnet,
-                ),
-                net=mainnet,
-            )
-        )
-        tests.append(
-            test(
-                name="mainnet p2pk compressed (0x03)",
-                addr="DsfiE2y23CGwKNxSGjbfPGeEW4xw1tamZdc",
-                encoded="DsfiE2y23CGwKNxSGjbfPGeEW4xw1tamZdc",
-                valid=True,
-                scriptAddress=ByteArray(
-                    "03e925aafc1edd44e7c7f1ea4fb7d265dc672f204c3d0c81930389c10b81fb75de"
-                ),
-                f=lambda: addrPK(
-                    ByteArray(
-                        "03e925aafc1edd44e7c7f1ea4fb7d265dc672f204c3d0c81930389c10b81fb75de"
-                    ),
-                    mainnet,
-                ),
-                net=mainnet,
-            )
-        )
-        tests.append(
-            test(
-                name="mainnet p2pk uncompressed (0x04)",
-                addr="DkM3EyZ546GghVSkvzb6J47PvGDyntqiDtFgipQhNj78Xm2mUYRpf",
-                encoded="DsfFjaADsV8c5oHWx85ZqfxCZy74K8RFuhK",
-                valid=True,
-                saddr="0264c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b16374dace6778f0",
-                scriptAddress=ByteArray(
-                    "0464c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b16374dace6778f"
-                    "0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3e80808a1fa3203904"
-                ),
-                f=lambda: addrPK(
-                    ByteArray(
-                        "0464c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b16374dace6778f"
-                        "0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3e80808a1fa3203904"
-                    ),
-                    mainnet,
-                ),
-                net=mainnet,
-            )
-        )
-        tests.append(
-            test(
-                name="testnet p2pk compressed (0x02)",
-                addr="Tso9sQD3ALqRsmEkAm7KvPrkGbeG2Vun7Kv",
-                encoded="Tso9sQD3ALqRsmEkAm7KvPrkGbeG2Vun7Kv",
-                valid=True,
-                scriptAddress=ByteArray(
-                    "026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06e"
-                ),
-                f=lambda: addrPK(
-                    ByteArray(
-                        "026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06e"
-                    ),
-                    testnet,
-                ),
-                net=testnet,
-            )
-        )
-        tests.append(
-            test(
-                name="testnet p2pk compressed (0x03)",
-                addr="TsWZ1EzypJfMwBKAEDYKuyHRGctqGAxMje2",
-                encoded="TsWZ1EzypJfMwBKAEDYKuyHRGctqGAxMje2",
-                valid=True,
-                scriptAddress=ByteArray(
-                    "030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af5"
-                ),
-                f=lambda: addrPK(
-                    ByteArray(
-                        "030844ee70d8384d5250e9bb3a6a73d4b5bec770e8b31d6a0ae9fb739009d91af5"
-                    ),
-                    testnet,
-                ),
-                net=testnet,
-            )
-        )
-        tests.append(
-            test(
-                name="testnet p2pk uncompressed (0x04)",
-                addr="TkKmMiY5iDh4U3KkSopYgkU1AzhAcQZiSoVhYhFymZHGMi9LM9Fdt",
-                encoded="Tso9sQD3ALqRsmEkAm7KvPrkGbeG2Vun7Kv",
-                valid=True,
-                saddr="026a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06e",
-                scriptAddress=ByteArray(
-                    "046a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06"
-                    "ed548c8c16fb5eb9007cb94220b3bb89491d5a1fd2d77867fca64217acecf2244"
-                ),
-                f=lambda: addrPK(
-                    ByteArray(
-                        "046a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06"
-                        "ed548c8c16fb5eb9007cb94220b3bb89491d5a1fd2d77867fca64217acecf2244"
-                    ),
-                    testnet,
-                ),
-                net=testnet,
-            )
-        )
-
-        # Negative P2PK tests.
-        tests.append(
-            test(
-                name="mainnet p2pk hybrid (0x06)",
-                addr="",
-                valid=False,
-                f=lambda: addrPK(
-                    ByteArray(
-                        "0664c44653d6567eff5753c5d24a682ddc2b2cadfe1b0c6433b16374dace6778f"
-                        "0b87ca4279b565d2130ce59f75bfbb2b88da794143d7cfd3e80808a1fa3203904"
-                    ),
-                    mainnet,
-                ),
-                net=mainnet,
-            )
-        )
-        tests.append(
-            test(
-                name="mainnet p2pk hybrid (0x07)",
-                addr="",
-                valid=False,
-                f=lambda: addrPK(
-                    ByteArray(
-                        "07348d8aeb4253ca52456fe5da94ab1263bfee16bb8192497f666389ca964f847"
-                        "98375129d7958843b14258b905dc94faed324dd8a9d67ffac8cc0a85be84bac5d"
-                    ),
-                    mainnet,
-                ),
-                net=mainnet,
-            )
-        )
-        tests.append(
-            test(
-                name="testnet p2pk hybrid (0x06)",
-                addr="",
-                valid=False,
-                f=lambda: addrPK(
-                    ByteArray(
-                        "066a40c403e74670c4de7656a09caa2353d4b383a9ce66eef51e1220eacf4be06"
-                        "ed548c8c16fb5eb9007cb94220b3bb89491d5a1fd2d77867fca64217acecf2244"
-                    ),
-                    testnet,
-                ),
-                net=testnet,
-            )
-        )
-        tests.append(
-            test(
-                name="testnet p2pk hybrid (0x07)",
-                addr="",
-                valid=False,
-                f=lambda: addrPK(
-                    ByteArray(
-                        "07edd40747de905a9becb14987a1a26c1adbd617c45e1583c142a635bfda9493d"
-                        "fa1c6d36735974965fe7b861e7f6fcc087dc7fe47380fa8bde0d9c322d53c0e89"
-                    ),
-                    testnet,
-                ),
-                net=testnet,
-            )
-        )
-
-        for test in tests:
-            # Decode addr and compare error against valid.
-            err = None
-            try:
-                decoded = txscript.decodeAddress(test.addr, test.net)
-            except DecredError as e:
-                err = e
-            self.assertEqual(err is None, test.valid, "%s error: %s" % (test.name, err))
-
-            if err is None:
-                # Ensure the stringer returns the same address as the original.
-                self.assertEqual(test.addr, decoded.string(), test.name)
-
-                # Encode again and compare against the original.
-                encoded = decoded.address()
-                self.assertEqual(test.encoded, encoded)
-
-                # Perform type-specific calculations.
-                if isinstance(decoded, dcraddr.AddressPubKeyHash):
-                    d = ByteArray(b58decode(encoded))
-                    saddr = d[2 : 2 + crypto.RIPEMD160_SIZE]
-
-                elif isinstance(decoded, dcraddr.AddressScriptHash):
-                    d = ByteArray(b58decode(encoded))
-                    saddr = d[2 : 2 + crypto.RIPEMD160_SIZE]
-
-                elif isinstance(decoded, dcraddr.AddressSecpPubKey):
-                    # Ignore the error here since the script
-                    # address is checked below.
-                    try:
-                        saddr = ByteArray(decoded.string())
-                    except ValueError:
-                        saddr = test.saddr
-
-                elif isinstance(decoded, dcraddr.AddressEdwardsPubKey):
-                    # Ignore the error here since the script
-                    # address is checked below.
-                    # saddr = ByteArray(decoded.String())
-                    self.fail("Edwards sigs unsupported")
-
-                elif isinstance(decoded, dcraddr.AddressSecSchnorrPubKey):
-                    # Ignore the error here since the script
-                    # address is checked below.
-                    # saddr = ByteArray(decoded.String())
-                    self.fail("Schnorr sigs unsupported")
-
-                # Check script address, as well as the Hash160 method for P2PKH and
-                # P2SH addresses.
-                self.assertEqual(saddr, decoded.scriptAddress(), test.name)
-
-                if isinstance(decoded, dcraddr.AddressPubKeyHash):
-                    self.assertEqual(decoded.pkHash, saddr)
-
-                if isinstance(decoded, dcraddr.AddressScriptHash):
-                    self.assertEqual(decoded.hash160(), saddr)
-
-            if not test.valid:
-                # If address is invalid, but a creation function exists,
-                # verify that it returns a nil addr and non-nil error.
-                if test.f is not None:
-                    try:
-                        test.f()
-                        self.fail(
-                            "%s: address is invalid but creating new address succeeded"
-                            % test.name
-                        )
-                    except DecredError:
-                        pass
-                continue
-
-            # Valid test, compare address created with f against expected result.
-            try:
-                addr = test.f()
-            except DecredError as e:
-                self.fail(
-                    "%s: address is valid but creating new address failed with error %s",
-                    test.name,
-                    e,
-                )
-            self.assertEqual(addr.scriptAddress(), test.scriptAddress, test.name)
-
     def test_extract_script_addrs(self):
         scriptVersion = 0
 
         def pkAddr(b):
-            addr = dcraddr.AddressSecpPubKey(b, mainnet)
+            addr = addrlib.AddressSecpPubKey(b, mainnet)
             # force the format to compressed, as per golang tests.
             addr.pubkeyFormat = crypto.PKFCompressed
             return addr
@@ -2682,7 +2261,7 @@ class TestTxScript(unittest.TestCase):
         """
         name (str): Short description of the test.
         script (ByteArray): The script to test.
-        addrs (list(dcraddr.AddressSecpPubKey)): Expected returned addresses.
+        addrs (list(addrlib.AddressSecpPubKey)): Expected returned addresses.
         reqSigs (int): Expected returned required signatures.
         scriptClass (int): expected returned signature class.
         exception (Exception): The expected exception if present.
@@ -2756,7 +2335,7 @@ class TestTxScript(unittest.TestCase):
                 name="standard p2pkh",
                 script=ByteArray("76a914ad06dd6ddee55cbca9a9e3713bd7587509a3056488ac"),
                 addrs=[
-                    dcraddr.newAddressPubKeyHash(
+                    addrlib.AddressPubKeyHash(
                         ByteArray("ad06dd6ddee55cbca9a9e3713bd7587509a30564"),
                         mainnet,
                         crypto.STEcdsaSecp256k1,
@@ -2769,7 +2348,7 @@ class TestTxScript(unittest.TestCase):
                 name="standard p2sh",
                 script=ByteArray("a91463bcc565f9e68ee0189dd5cc67f1b0e5f02f45cb87"),
                 addrs=[
-                    dcraddr.newAddressScriptHashFromHash(
+                    addrlib.AddressScriptHash(
                         ByteArray("63bcc565f9e68ee0189dd5cc67f1b0e5f02f45cb"), mainnet
                     )
                 ],
@@ -2971,7 +2550,7 @@ class TestTxScript(unittest.TestCase):
         the correct scripts for the various types of addresses.
         """
         # 1MirQ9bwyQcGVJPwKUgapu5ouK2E2Ey4gX
-        p2pkhMain = dcraddr.newAddressPubKeyHash(
+        p2pkhMain = addrlib.AddressPubKeyHash(
             ByteArray("e34cce70c86373273efcc54ce7d2a491bb4a0e84"),
             mainnet,
             crypto.STEcdsaSecp256k1,
@@ -2979,24 +2558,18 @@ class TestTxScript(unittest.TestCase):
 
         # Taken from transaction:
         # b0539a45de13b3e0403909b8bd1a555b8cbe45fd4e3f3fda76f3a5f52835c29d
-        p2shMain = dcraddr.newAddressScriptHashFromHash(
+        p2shMain = addrlib.AddressScriptHash(
             ByteArray("e8c300c87986efa84c37c0519929019ef86eb5b4"), mainnet
         )
 
-        # # disabled until Schnorr signatures implemented
-        # # mainnet p2pk 13CG6SJ3yHUXo4Cr2RY4THLLJrNFuG3gUg
-        # p2pkCompressedMain = dcraddr.newAddressPubKey(ByteArray(
-        #     "02192d74d0cb94344c9569c2e77901573d8d7903c3ebec3a957724895dca52c6b4"),
-        #     mainnet)
-
-        p2pkCompressed2Main = dcraddr.AddressSecpPubKey(
+        p2pkCompressed2Main = addrlib.AddressSecpPubKey(
             ByteArray(
                 "03b0bd634234abbb1ba1e986e884185c61cf43e001f9137f23c2c409273eb16e65"
             ),
             mainnet,
         )
 
-        p2pkUncompressedMain = dcraddr.AddressSecpPubKey(
+        p2pkUncompressedMain = addrlib.AddressSecpPubKey(
             ByteArray(
                 "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5"
                 "cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3"
@@ -3007,7 +2580,7 @@ class TestTxScript(unittest.TestCase):
         # dcrd/tscript/standard_test.go
         p2pkUncompressedMain.pubkeyFormat = crypto.PKFCompressed
 
-        class BogusAddress(dcraddr.AddressPubKeyHash):
+        class BogusAddress(addrlib.AddressPubKeyHash):
             pass
 
         bogusAddress = (
@@ -3537,16 +3110,16 @@ def test_merge_scripts():
     privKey1 = root.child(0).privateKey().key
     privKey2 = root.child(1).privateKey().key
     privKey3 = root.child(2).privateKey().key
-    pub1 = dcraddr.AddressSecpPubKey(
+    pub1 = addrlib.AddressSecpPubKey(
         root.child(0).publicKey().serializeCompressed(), testnet
     )
-    pub2 = dcraddr.AddressSecpPubKey(
+    pub2 = addrlib.AddressSecpPubKey(
         root.child(1).publicKey().serializeCompressed(), testnet
     )
-    pub3 = dcraddr.AddressSecpPubKey(
+    pub3 = addrlib.AddressSecpPubKey(
         root.child(2).publicKey().serializeCompressed(), testnet
     )
-    pub4 = dcraddr.AddressSecpPubKey(
+    pub4 = addrlib.AddressSecpPubKey(
         root.child(3).publicKey().serializeCompressed(), testnet
     )
     # P2PKH is a valid pay to public key hash script.

--- a/decred/tests/unit/wallet/test_accounts.py
+++ b/decred/tests/unit/wallet/test_accounts.py
@@ -7,7 +7,7 @@ import pytest
 
 from decred import DecredError
 from decred.crypto import crypto, rando
-from decred.dcr import nets, account
+from decred.dcr import account, nets
 from decred.util import chains, database, encode
 from decred.wallet import accounts
 

--- a/decred/tests/unit/wallet/test_accounts.py
+++ b/decred/tests/unit/wallet/test_accounts.py
@@ -7,7 +7,7 @@ import pytest
 
 from decred import DecredError
 from decred.crypto import crypto, rando
-from decred.dcr import nets
+from decred.dcr import nets, account
 from decred.util import chains, database, encode
 from decred.wallet import accounts
 
@@ -105,7 +105,7 @@ def test_discover(prepareLogger):
 
     coinExtKey = acctMgr.coinKey(cryptoKey)
     acct2ExtKey = coinExtKey.deriveAccountKey(2).neuter().child(0)
-    acct2Addr5 = acct2ExtKey.deriveChildAddress(5, nets.mainnet)
+    acct2Addr5 = account.deriveChildAddress(acct2ExtKey, 5, nets.mainnet)
     txs[acct2Addr5] = ["tx"]
     acctMgr.discover(cryptoKey)
     assert len(acctMgr.accounts) == 3


### PR DESCRIPTION
Resolves #64.

- Moves the `Address*` types to a new module called `addrlib`, which is somewhat similar to **dcrd/dcrutil/address.go**. 

- Standardizes the argument type and order in address constructors. They all take a `ByteArray` as the first argument and network parameters as the second. 

- Drops extraneous constructor functions `newAddressPubKey`, `newAddressPubKeyHash`, `newAddressScriptHash`. Just use the class constructors. Moves `newAddressScriptHashFromHash` to a `staticmethod` on the `AddressScriptHash` class.

- All address types now inherit from the `Address` class, which also implements the `Blobber` API. 

- All address classes implement comparison `__eq__` methods.

- Moves `deriveChildAddress` from a method of `ExtendedKey` to a function in **account**. The crypto module does not have any concept of an address now, though it still handles base-58 encoding and decoding.
