### PR TITLE
util: helpers.py refactor

### DIFF
--- a/decred/decred/dcr/rpc.py
+++ b/decred/decred/dcr/rpc.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 from decred import DecredError
 from decred.util import tinyhttp, ws
 from decred.util.encode import ByteArray
-from decred.util.helpers import coinify, getLogger
+from decred.util.helpers import getLogger
 
 from . import agenda, txscript
 from .wire.msgblock import BlockHeader
@@ -21,6 +21,19 @@ from .wire.msgtx import MsgTx, TxOut, TxTreeStake
 
 
 log = getLogger("RPC")
+
+
+def coinify(atoms):
+    """
+    Convert the smallest unit of a coin into its coin value.
+
+    Args:
+        atoms (int): 1e8 division of a coin.
+
+    Returns:
+        float: The coin value.
+    """
+    return round(atoms / 1e8, 8)
 
 
 def stringify(thing):
@@ -160,7 +173,7 @@ class Client:
         )
         resp = Response(rawRes)
         if resp.error:
-            raise Exception(f"{method} error: {resp.error}")
+            raise DecredError(f"{method} error: {resp.error}")
         return resp.result
 
     def addNode(self, addr, subCmd):
@@ -3424,7 +3437,7 @@ class WebsocketClient(Client):
         self.ws.send(req.json())
         resp = q.get(timeout=self.requestTimeout)
         if resp.error:
-            raise Exception(f"{method} error: {resp.error}")
+            raise DecredError(f"{method} error: {resp.error}")
         return resp.result
 
     def on_message(self, msg):

--- a/decred/decred/util/helpers.py
+++ b/decred/decred/util/helpers.py
@@ -5,73 +5,34 @@ See LICENSE for details
 """
 
 import calendar
-import configparser
-import json
 import logging
 from logging.handlers import RotatingFileHandler
 import os
-from os.path import expanduser
-import platform
-import shutil
 import sys
-from tempfile import TemporaryDirectory
 import time
 import traceback
-import webbrowser
-
-from appdirs import AppDirs
 
 
-def coinify(atoms):
+def formatTraceback(err):
     """
-    Convert the smallest unit of a coin into its coin value.
+    Format a traceback for an error.
 
     Args:
-        atoms (int): 1e8 division of a coin.
-
-    Returns:
-        float: The coin value.
-    """
-    return round(atoms / 1e8, 8)
-
-
-def normalizeNetName(netName):
-    """
-    Remove the numerals from testnet.
-
-    Args:
-        netName (string): The raw network name.
-
-    Returns:
-        string: The network name with numerals stripped.
-    """
-    return "testnet" if netName == "testnet3" else netName
-
-
-def openInBrowser(url):
-    """
-    Open url in the users browser
-
-    Args:
-        url (string): the url to open.
-    """
-    webbrowser.open(url, new=2)
-
-
-def formatTraceback(e):
-    """
-    Format a traceback for an exception.
+        err (BaseException): The error the traceback is extracted from.
 
     Returns:
         str: The __str__() of the traceback, followed by the standard formatting
             of the traceback on the following lines.
     """
-    return "%s\n%s" % (e, traceback.print_tb(e.__traceback__))
+    return f"{err}\n{traceback.print_tb(err.__traceback__)}"
 
 
 def mkdir(path):
     """
-    Create the directory if it doesn't exist.
+    Create the directory if it doesn't exist. Uses os.path .
+
+    Args:
+        path (str, bytes): the directory path.
     """
     if os.path.isdir(path):
         return True
@@ -81,28 +42,14 @@ def mkdir(path):
     return True
 
 
-def moveFile(ogPath, newPath):
-    """
-    Move a file.
-
-    Args:
-        ogPath (str): The filepath of the file to move.
-        newPath (str): The destination filepath.
-    """
-    shutil.move(ogPath, newPath)
-
-
-def yearmonthday(t):
-    """
-    Returns a tuple (year, month, day) with 1 <= month <= 12
-    and 1 <= day <= 31
-    """
-    return tuple(int(x) for x in time.strftime("%Y %m %d", time.gmtime(t)).split())
-
-
 def mktime(year, month=None, day=None):
     """
-    Make a timestamp from year, month, day. See `yearmonthday`.
+    Make a timestamp from year, month, day.
+
+    Args:
+        year (int): the year.
+        month (int), optional: the month.
+        day (int), optional: the day.
     """
     if month:
         if day:
@@ -116,104 +63,6 @@ def mktime(year, month=None, day=None):
             time.strptime("%i-%s" % (year, str(month).zfill(2)), "%Y-%m")
         )
     return calendar.timegm(time.strptime(str(year), "%Y"))
-
-
-class Benchmarker:
-    """
-    A class for basic execution timing.
-    """
-
-    on = False
-
-    def __init__(self, startStr=None):
-        if not self.on:
-            return
-        if startStr:
-            print(startStr)
-        self.start()
-
-    def start(self):
-        if self.on:
-            tNow = time.time() * 1000
-            self.startTime = tNow
-            self.lapTime = tNow
-
-    def resetLap(self):
-        if self.on:
-            tNow = time.time() * 1000
-            self.lapTime = tNow
-
-    def lap(self, identifier):
-        if self.on:
-            tNow = time.time() * 1000
-            print("  %i ms to %s" % (int(tNow - self.lapTime), identifier))
-            self.resetLap()
-
-    def end(self, identifier):
-        if self.on:
-            tNow = time.time() * 1000
-            print("%i ms to %s" % (int(tNow - self.startTime), identifier))
-            self.start()
-
-
-def formatNumber(number, billions="B", spacer=" ", isMoney=False):
-    """
-    Format the number to a string with max 3 sig figs, and appropriate unit
-    multipliers.
-
-    Args:
-        number (float or int):  The number to format.
-        billions (str): Default "G". The unit multiplier to use for billions.
-            "B" is also common.
-        spacer (str): Default " ". A spacer to insert between the number and
-            the unit multiplier. Empty string also common.
-        isMoney (bool): If True, a number less than 0.005 will always be 0.00,
-            and a number will never be formatted with just one decimal place.
-    """
-    if number == 0:
-        return "0%s" % spacer
-
-    absVal = float(abs(number))
-    flt = float(number)
-    if absVal >= 1e12:  # >= 1 trillion
-        return "%.2e" % flt
-    if absVal >= 10e9:  # > 10 billion
-        return "%.1f%s%s" % (flt / 1e9, spacer, billions)
-    if absVal >= 1e9:  # > 1 billion
-        return "%.2f%s%s" % (flt / 1e9, spacer, billions)
-    if absVal >= 100e6:  # > 100 million
-        return "%i%sM" % (int(round(flt / 1e6)), spacer)
-    if absVal >= 10e6:  # > 10 million
-        return "%.1f%sM" % (flt / 1e6, spacer)
-    if absVal >= 1e6:  # > 1 million
-        return "%.2f%sM" % (flt / 1e6, spacer)
-    if absVal >= 100e3:  # > 100 thousand
-        return "%i%sk" % (int(round(flt / 1e3)), spacer)
-    if absVal >= 10e3:  # > 10 thousand
-        return "%.1f%sk" % (flt / 1e3, spacer)
-    if absVal >= 1e3:  # > 1 thousand
-        return "%.2f%sk" % (flt / 1e3, spacer)
-    if isinstance(number, int):
-        return "%i" % number
-    if absVal >= 100:
-        return "%i%s" % (flt, spacer)
-    if absVal >= 10:
-        if isMoney:
-            return "%.2f%s" % (
-                flt,
-                spacer,
-            )  # Extra degree of precision here because otherwise money looks funny.
-        return "%.1f%s" % (
-            flt,
-            spacer,
-        )  # Extra degree of precision here because otherwise money looks funny.
-    # if absVal > 1:
-    #   return "%.2f%s" % (absVal, spacer)
-    if absVal > 0.01:
-        return "%.2f%s" % (flt, spacer)
-    if isMoney:
-        return "0.00%s" % spacer
-    return ("%.2e%s" % (flt, spacer)).replace("e-0", "e-")
 
 
 class LogSettings:
@@ -286,124 +135,3 @@ def getLogger(name):
     l.setLevel(LogSettings.moduleLevels.get(name, LogSettings.defaultLevel))
     LogSettings.loggers[name] = l
     return l
-
-
-class ConsoleLogger:
-    """
-    A logger that only prints to stdout.
-    """
-
-    @staticmethod
-    def log(s):
-        print(s)
-
-    debug = log
-    info = log
-    warning = log
-    error = log
-    critical = log
-
-
-def fetchSettingsFile(filepath):
-    """
-    Fetches the JSON settings file, creating an empty JSON object if necessary.
-    """
-    if not os.path.isfile(filepath):
-        with open(filepath, "w+") as file:
-            file.write("{}")
-    return loadJSON(filepath)
-
-
-def saveFile(path, contents, binary=False):
-    """
-    Atomic file save.
-    """
-    with TemporaryDirectory() as tempDir:
-        tmpPath = os.path.join(tempDir, "tmp.tmp")
-        with open(tmpPath, "wb" if binary else "w") as f:
-            f.write(contents)
-            f.flush()
-            os.fsync(f.fileno())
-        shutil.move(tmpPath, path)
-
-
-def appDataDir(appName):
-    """
-    appDataDir returns an operating system specific directory to be used for
-    storing application data for an application.
-    """
-    if appName == "" or appName == ".":
-        return "."
-
-    # The caller really shouldn't prepend the appName with a period, but
-    # if they do, handle it gracefully by stripping it.
-    appName = appName.lstrip()
-    appNameUpper = appName.capitalize()
-    appNameLower = appName.lower()
-
-    # Get the OS specific home directory.
-    homeDir = expanduser("~")
-
-    # Fall back to standard HOME environment variable that works
-    # for most POSIX OSes.
-    if homeDir == "":
-        homeDir = os.getenv("HOME")
-
-    opSys = platform.system()
-    if opSys == "Windows":
-        # Windows XP and before didn't have a LOCALAPPDATA, so fallback
-        # to regular APPDATA when LOCALAPPDATA is not set.
-        return AppDirs(appNameUpper, "").user_data_dir
-
-    elif opSys == "Darwin":
-        if homeDir != "":
-            return os.path.join(homeDir, "Library", "Application Support", appNameUpper)
-
-    else:
-        if homeDir != "":
-            return os.path.join(homeDir, "." + appNameLower)
-
-    # Fall back to the current directory if all else fails.
-    return "."
-
-
-def readINI(path, keys):
-    """
-    Attempt to read the specified keys from the INI-formatted configuration
-    file. All sections will be searched. A dict with discovered keys and
-    values will be returned. If a key is not discovered, it will not be
-    present in the result.
-
-    Args:
-        path (str): The path to the INI configuration file.
-        keys (list(str)): Keys to search for.
-
-    Returns:
-        dict: Discovered keys and values.
-    """
-    config = configparser.ConfigParser()
-    # Need to add a section header since configparser doesn't handle sectionless
-    # INI format.
-    with open(path) as f:
-        config.read_string("[tinydecred]\n" + f.read())  # This line does the trick.
-    res = {}
-    for section in config.sections():
-        for k in config[section]:
-            if k in keys:
-                res[k] = config[section][k]
-    return res
-
-
-def saveJSON(filepath, thing, **kwargs):
-    """
-    Save the object to JSON.
-    """
-    saveFile(filepath, json.dumps(thing, **kwargs))
-
-
-def loadJSON(filepath):
-    """
-    Load the JSON file into a Python dict or list.
-    """
-    with open(filepath, "r") as f:
-        return json.loads(f.read())

--- a/decred/tests/unit/util/test_helpers.py
+++ b/decred/tests/unit/util/test_helpers.py
@@ -4,8 +4,36 @@ See LICENSE for details
 """
 
 import logging
+import os
 
+from decred import DecredError
 from decred.util import helpers
+
+
+def test_formatTraceback():
+    # Cannot actually raise an error because pytest intercepts it.
+    assert helpers.formatTraceback(DecredError("errmsg")) == "errmsg\nNone"
+
+
+def test_mkdir(tmp_path):
+    fpath = tmp_path / "test_file"
+    f = open(fpath, "w")
+    f.close()
+    assert not helpers.mkdir(fpath)
+    dpath = tmp_path / "test_dir"
+    assert helpers.mkdir(dpath)
+    assert os.path.isdir(dpath)
+    assert helpers.mkdir(dpath)
+
+
+def test_mktime():
+    assert helpers.mktime(1970) == 0
+    assert helpers.mktime(1970, month=None, day=1) == 0
+    assert helpers.mktime(1970, month=1) == 0
+    assert helpers.mktime(1970, month=1, day=1) == 0
+    assert helpers.mktime(1970, month=2) == 2678400
+    assert helpers.mktime(1970, month=2, day=1) == 2678400
+    assert helpers.mktime(1970, month=2, day=2) == 2764800
 
 
 def test_prepareLogging(tmp_path):

--- a/tinywallet/tinywallet/config.py
+++ b/tinywallet/tinywallet/config.py
@@ -76,7 +76,7 @@ class CmdArgs:
         args, unknown = parser.parse_known_args()
         if unknown:
             sys.exit(f"unknown arguments:{unknown}")
-        self.netParams = None
+        self.netParams = nets.mainnet
         if args.simnet:
             self.netParams = nets.simnet
         elif args.testnet:
@@ -85,7 +85,6 @@ class CmdArgs:
             print("**********************************************************")
             print(" WARNING. WALLET FOR TESTING ONLY. NOT FOR USE ON MAINNET ")
             print("**********************************************************")
-            sys.exit(1)
         if args.loglevel:
             try:
                 if "," in args.loglevel or ":" in args.loglevel:

--- a/tinywallet/tinywallet/config.py
+++ b/tinywallet/tinywallet/config.py
@@ -9,6 +9,7 @@ Configuration settings for TinyDecred.
 import argparse
 import logging
 import os
+import sys
 
 from appdirs import AppDirs
 
@@ -67,7 +68,6 @@ class CmdArgs:
     def __init__(self):
         self.logLevel = logging.INFO
         self.moduleLevels = {}
-        self.netParams = nets.mainnet
         parser = argparse.ArgumentParser()
         parser.add_argument("--loglevel")
         netGroup = parser.add_mutually_exclusive_group()
@@ -75,7 +75,7 @@ class CmdArgs:
         netGroup.add_argument("--testnet", action="store_true", help="use testnet")
         args, unknown = parser.parse_known_args()
         if unknown:
-            exit(f"unknown arguments:{unknown}")
+            sys.exit(f"unknown arguments:{unknown}")
         self.netParams = None
         if args.simnet:
             self.netParams = nets.simnet
@@ -85,6 +85,7 @@ class CmdArgs:
             print("**********************************************************")
             print(" WARNING. WALLET FOR TESTING ONLY. NOT FOR USE ON MAINNET ")
             print("**********************************************************")
+            sys.exit(1)
         if args.loglevel:
             try:
                 if "," in args.loglevel or ":" in args.loglevel:
@@ -92,8 +93,8 @@ class CmdArgs:
                     self.moduleLevels = {k: logLvl(v) for k, v in pairs}
                 else:
                     self.logLevel = logLvl(args.loglevel)
-            except:
-                exit(f"malformed loglevel specifier: {args.loglevel}")
+            except Exception:
+                sys.exit(f"malformed loglevel specifier: {args.loglevel}")
 
 
 class DB:

--- a/tinywallet/tinywallet/mpl.py
+++ b/tinywallet/tinywallet/mpl.py
@@ -73,7 +73,9 @@ def getMonthTicks(start, end, increment, offset=0):
     """
     xLabels = []
     xTicks = []
-    y, m, d = helpers.yearmonthday(start)
+    y, m, d = tuple(
+        int(x) for x in time.strftime("%Y %m %d", time.gmtime(start)).split()
+    )
 
     def normalize(y, m):
         if m > 12:

--- a/tinywallet/tinywallet/screens.py
+++ b/tinywallet/tinywallet/screens.py
@@ -6,9 +6,11 @@ See LICENSE for detail
 
 import os
 import random
+import shutil
 import threading
 import time
 from urllib.parse import urlsplit, urlunsplit
+import webbrowser
 
 from PyQt5 import QtCore, QtGui, QtSvg, QtWidgets
 
@@ -37,6 +39,16 @@ FADE_IN_ANIMATION = "fadeinanimation"
 formatTraceback = helpers.formatTraceback
 
 app = None
+
+
+def openInBrowser(url):
+    """
+    Open url in the users browser
+
+    Args:
+        url (string): the url to open.
+    """
+    webbrowser.open(url, new=2)
 
 
 def sprintDcr(atoms, comma=""):
@@ -931,7 +943,7 @@ class InitializationScreen(Screen):
             return
 
         destination = app.walletFilename()
-        helpers.moveFile(walletPath, destination)
+        shutil.move(walletPath, destination)
         app.initialize()
 
     def restoreClicked(self):
@@ -1775,7 +1787,7 @@ class LiveTicketsScreen(Screen):
         hostname = nets.normalizeName(cfg.netParams.Name)
         utxo = self.liveTickets[item.text()[:8]]
         url = urlunsplit(("https", f"{hostname}.dcrdata.org", f"/{utxo.txid}", "", ""))
-        helpers.openInBrowser(url)
+        openInBrowser(url)
 
     def addItems(self, liveTickets):
         """
@@ -2229,14 +2241,14 @@ class PoolScreen(Screen):
         Connected to the "see all" button clicked signal. Open the fu
         decred.org VSP list in the browser.
         """
-        helpers.openInBrowser("https://decred.org/vsp/")
+        openInBrowser("https://decred.org/vsp/")
 
     def linkClicked(self):
         """
         Callback from the clicked signal on the pool URL QLabel. Opens the
         pool's homepage in the users browser.
         """
-        helpers.openInBrowser(self.poolUrl.text())
+        openInBrowser(self.poolUrl.text())
 
     def poolClicked(self):
         """


### PR DESCRIPTION
This heavily refactors `decred/util/helpers.py` while extending its test coverage (up to 93% total). Part of #70.
All unused functions and classes have been removed.
All code used only once has been moved to the caller sites.
Tests have been written for the remaining functions that did not have any.
Here are the details.

## Code left there

### `formatTraceback` function

Used by:

* `dcr/dcrdata.py`, `util/tinyhttp/py` in `decred`
* `app.py`, `qutilities.py`, `screens.py` in `tinywallet`

### `mkdir` function

Used by:

* `decred/wallet/simple.py`
* `app.py, config.py` in `tinywallet`

### `mktime` function

Used by:

* `examples/plot_ticket_price.py`
* `dcr/calc.py`
* `tinywallet/mpl.py`

### `LogSettings` class

Used by the same file

### `prepareLogging` function

Used by:

* `decred/tests/conftest.py`
* `unit/dcr/wire/test_wire.py`
* `tinywallet/app.py`

### `getLogger` function

Used by:

* the same file
* `account.py`, `dcrdata.py`, `rpc/py`, `txscript.py` in `decred/dcr`
* `accounts.py`, `wallet.py` in `decred/wallet`
* `app.py`, `qutilities.py`, `screens.py` in `tinywallet`

## Code moved elsewhere

### `coinify` function

Only used in `dcr/rpc.py`, moved there

### `openInBrowser` function

Only used in `tinywallet/screens.py`, moved there

### `moveFile` function

Used once by `tinywallet/screens.py`
One-liner moved there, function removed

### `yearmonthday` function

Used once in `tinywallet/mpl.py`
One-liner moved there, function removed

### `appDataDir` function

Used once in `integration/dcr/test_rpc.py`, moved there

### `readINI function`

Used once in integration/dcr/test_rpc.py, moved there

## Code removed because unused

* `normalizeNetName` function
* `Benchmarker` class
* `formatNumber` function
* `ConsoleLogger` class
* `fetchSettingsFile` function
* `saveFile` function
* `saveJSON` function
* `loadJSON` function