### PR TITLE
txscript: Add asSmallInt test

### DIFF
--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -1699,6 +1699,12 @@ def payToAddrScript(addr):
     """
     PayToAddrScript creates a new script to pay a transaction output to a the
     specified address.
+
+    Args:
+        addr (Address): An address.
+
+    Returns:
+        ByteArray: The pay to address script.
     """
     if isinstance(addr, addrlib.AddressPubKeyHash):
         if addr.sigType == crypto.STEcdsaSecp256k1:

--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -1661,12 +1661,22 @@ def checkSStx(tx):
             )
 
 
-# asSmallInt returns the passed opcode, which must be true according to
-# isSmallInt(), as an integer.
 def asSmallInt(op):
+    """
+    asSmallInt returns the passed opcode, which must be true according to
+    isSmallInt(), as an integer.
+
+    Args:
+        op (int): An opcode.
+
+    Returns:
+        int: The opcode as an integer.
+    """
+    if not isSmallInt(op):
+        raise DecredError(f"asSmallInt:{op} is not a small int")
     if op == opcode.OP_0:
         return 0
-    return int(op - (opcode.OP_1 - 1))
+    return op - (opcode.OP_1 - 1)
 
 
 def isSmallInt(op):

--- a/decred/tests/unit/dcr/test_txscript.py
+++ b/decred/tests/unit/dcr/test_txscript.py
@@ -4333,3 +4333,84 @@ def test_multi_sig_script():
         assert (
             res == test["want"]
         ), f'wanted {test["want"].hex()} but got {res.hex()} for test {test["name"]}'
+
+
+def test_pay_to_addr_script():
+    psf = parseShortForm
+    hash160 = crypto.hash160(0)
+    addrPubKeyHash = addrlib.AddressPubKeyHash(
+        hash160, testnet, crypto.STEcdsaSecp256k1
+    )
+    addrScriptHash = addrlib.AddressScriptHash(hash160, testnet)
+    addrPubKeyHashEdwards = addrlib.AddressPubKeyHash(
+        hash160, testnet, crypto.STEcdsaSecp256k1
+    )
+    addrPubKeyHashEdwards.sigType = crypto.STEd25519
+    addrPubKeyHashSchnorr = addrlib.AddressPubKeyHash(
+        hash160, testnet, crypto.STEcdsaSecp256k1
+    )
+    addrPubKeyHashSchnorr.sigType = crypto.STSchnorrSecp256k1
+    pubBytes = psf("0x03 {}".format(hex(Curve.curve.N)))
+    addrSecpPubKey = addrlib.AddressSecpPubKey(pubBytes, testnet)
+    addrEdwardsPubKey = addrlib.AddressEdwardsPubKey.__new__(
+        addrlib.AddressEdwardsPubKey
+    )
+    addrSchnorrPubKey = addrlib.AddressSecSchnorrPubKey.__new__(
+        addrlib.AddressSecSchnorrPubKey
+    )
+    """
+    name (str): Short description of the test.
+    addr (Address): An address.
+    wantException (Exception): The exception expected if any.
+    want (ByteArray): The pay to address script.
+    """
+    tests = [
+        dict(
+            name="address pubkey hash",
+            addr=addrPubKeyHash,
+            want=psf(
+                "DUP HASH160 0x{} EQUALVERIFY CHECKSIG".format(
+                    txscript.addData(hash160).hex()
+                )
+            ),
+        ),
+        dict(
+            name="edwards hash not implemented",
+            addr=addrPubKeyHashEdwards,
+            wantException=NotImplementedError,
+        ),
+        dict(
+            name="schnorr hash not implemented",
+            addr=addrPubKeyHashEdwards,
+            wantException=NotImplementedError,
+        ),
+        dict(
+            name="address script hash",
+            addr=addrScriptHash,
+            want=psf("HASH160 0x{} EQUAL".format(txscript.addData(hash160).hex())),
+        ),
+        dict(
+            name="address secp pubkey",
+            addr=addrSecpPubKey,
+            want=psf("0x{} CHECKSIG".format(txscript.addData(pubBytes).hex())),
+        ),
+        dict(
+            name="edwards pubkey not implemented",
+            addr=addrEdwardsPubKey,
+            wantException=NotImplementedError,
+        ),
+        dict(
+            name="schnorr pubkey not implemented",
+            addr=addrSchnorrPubKey,
+            wantException=NotImplementedError,
+        ),
+    ]
+    for test in tests:
+        if test.get("wantException"):
+            with pytest.raises(test["wantException"]):
+                res = txscript.payToAddrScript(test["addr"])
+            continue
+        res = txscript.payToAddrScript(test["addr"])
+        assert (
+            res == test["want"]
+        ), f'wanted {test["want"].hex()} but got {res.hex()} for test {test["name"]}'

--- a/decred/tests/unit/dcr/test_txscript.py
+++ b/decred/tests/unit/dcr/test_txscript.py
@@ -4414,3 +4414,37 @@ def test_pay_to_addr_script():
         assert (
             res == test["want"]
         ), f'wanted {test["want"].hex()} but got {res.hex()} for test {test["name"]}'
+
+
+def test_as_small_int():
+    """
+    name (str): Short description of the test.
+    op (int): An opcode.
+    wantException (Exception): The exception expected if any.
+    want (int): The opcode as an integer.
+    """
+    tests = [
+        dict(name="zero", op=opcode.OP_0, want=0,),
+        dict(name="lowest converted small int", op=opcode.OP_1, want=1,),
+        dict(
+            name="one less than lowest converted small int",
+            op=opcode.OP_1 - 1,
+            wantException=DecredError,
+        ),
+        dict(name="highest converted small int", op=opcode.OP_16, want=16,),
+        dict(
+            name="one more than highest converted small int",
+            op=opcode.OP_16 + 1,
+            wantException=DecredError,
+        ),
+        dict(name="an opcode in the middle", op=opcode.OP_8, want=8,),
+    ]
+    for test in tests:
+        if test.get("wantException"):
+            with pytest.raises(test["wantException"]):
+                res = txscript.asSmallInt(test["op"])
+            continue
+        res = txscript.asSmallInt(test["op"])
+        assert (
+            res == test["want"]
+        ), f'wanted {test["want"]} but got {res} for test {test["name"]}'


### PR DESCRIPTION
Throw an exception if the passed opcode is not isSmallInt. Add
Documentation. Remove redundant conversion to int.