### PR TITLE
blockchain: add a dcrd-based Blockchain class

### DIFF
--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -55,25 +55,6 @@ def filterCrazyAddress(addrs):
     return [a for a in addrs if a != CrazyAddress]
 
 
-def deriveChildAddress(branchXPub, i, netParams):
-    """
-    The base-58 encoded address for the i'th child.
-
-    Args:
-        i (int): Child number.
-        netParams (module): Network parameters.
-
-    Returns:
-        Address: Child address.
-    """
-    child = branchXPub.child(i)
-    return addrlib.AddressPubKeyHash(
-        crypto.hash160(child.publicKey().serializeCompressed().b),
-        netParams,
-        crypto.STEcdsaSecp256k1,
-    ).string()
-
-
 class KeySource:
     """
     Implements the KeySource API from tinydecred.api. Must provide access to
@@ -909,11 +890,11 @@ class Account:
         extPub = pubX.child(EXTERNAL_BRANCH)
         intPub = pubX.child(INTERNAL_BRANCH)
         addrs = [
-            deriveChildAddress(extPub, idx, blockchain.params)
+            addrlib.deriveChildAddress(extPub, idx, blockchain.params)
             for idx in range(DefaultGapLimit)
         ]
         addrs += [
-            deriveChildAddress(intPub, idx, blockchain.params)
+            addrlib.deriveChildAddress(intPub, idx, blockchain.params)
             for idx in range(DefaultGapLimit)
         ]
         return blockchain.addrsHaveTxs(addrs)
@@ -1420,7 +1401,7 @@ class Account:
         def nextAddr():
             idx = len(branchAddrs)
             try:
-                addr = deriveChildAddress(branchKey, idx, self.netParams)
+                addr = addrlib.deriveChildAddress(branchKey, idx, self.netParams)
             except crypto.CrazyKeyError:
                 addr = CrazyAddress
             branchAddrs.append(addr)

--- a/decred/decred/dcr/addrlib.py
+++ b/decred/decred/dcr/addrlib.py
@@ -446,3 +446,20 @@ def decodeAddressPubKey(decoded, netParams):
         raise NotImplementedError("Schnorr signatures not implemented")
     else:
         raise NotImplementedError(f"unknown address type {suite}")
+
+
+def deriveChildAddress(branchXPub, i, netParams):
+    """
+    The base-58 encoded address for the i'th child.
+
+    Args:
+        i (int): Child number.
+        netParams (module): Network parameters.
+
+    Returns:
+        str: Child address, as a base-58 encoded string.
+    """
+    child = branchXPub.child(i)
+    return AddressPubKeyHash(
+        hash160(child.publicKey().serializeCompressed().b), netParams, STEcdsaSecp256k1,
+    ).string()

--- a/decred/decred/dcr/blockchain.py
+++ b/decred/decred/dcr/blockchain.py
@@ -176,7 +176,7 @@ class LocalNode:
         Returns:
             list(ByteArray): A list of hashes for blocks removed from mainchain.
         """
-        synced = 0
+        synced = 0  # Keep a count of the number of headers synced.
         mainchain = self.mainchainDB
 
         # Get the root header
@@ -227,7 +227,7 @@ class LocalNode:
 
     def syncHeaderRange(self, start, end):
         """
-        Retrieve and store mainchain block headers in the range [start:end),
+        Retrieve and store mainchain block headers in the range (start:end],
         e.g. start is not included.
 
         Args:
@@ -243,6 +243,7 @@ class LocalNode:
 
         storage = self.headerDB
         mainchain = self.mainchainDB
+        # Keep a count of the actual number synced. This can be < start - end.
         synced = 0
         if start == 0:
             # store the genesis block

--- a/decred/decred/dcr/blockchain.py
+++ b/decred/decred/dcr/blockchain.py
@@ -1,0 +1,312 @@
+"""
+Copyright (c) 2020, the Decred developers
+"""
+
+
+import time
+from urllib.parse import urlsplit, urlunsplit
+
+from decred.crypto import crypto
+from decred.dcr import addrlib, rpc
+from decred.dcr.wire.msgblock import BlockHeader
+from decred.util import database, helpers
+from decred.util.encode import ByteArray
+
+
+log = helpers.getLogger("blockchain")
+
+
+def getSocketURL(url):
+    """
+    Turn the HTTP/HTTPS URL into a WS/WSS one.
+
+    Args:
+        url (string): The DCRD RPC URL.
+    Returns:
+        string: the WebSocket URL.
+    """
+    url = urlsplit(url)
+    scheme = "wss" if url.scheme in ("https", "wss") else "ws"
+    return urlunsplit((scheme, url.netloc, "/ws", "", ""))
+
+
+class LocalNode:
+    """
+    LocalNode is a Blockchain based on an authenticated dcrd websocket
+    connection.
+    """
+
+    def __init__(self, netParams, dbPath, url, user, pw, certPath=None):
+        """
+        Args:
+            netParams (module): The network parameters.
+            dbPath (str or Path): A path to a database file for use by the LocalNode.
+            url (str): The URL for the local node, with protocol.
+            user (str): The user name for authenticating the connection.
+            pw (str): The password for authenticating the connection.
+            certPath (str or Path): A filepath to the dcrd TLS certificate.
+        """
+        self.netParams = netParams
+        self.db = database.KeyValueDatabase(dbPath)
+        self.mainchainDB = self.db.child(
+            "mainchain", datatypes=("INTEGER", "BLOB"), blobber=ByteArray
+        )
+        self.headerDB = self.db.child(
+            "headers", blobber=BlockHeader, keyBlobber=ByteArray
+        )
+        # self.txsDB = self.db.child("txs", blobber=MsgTx, keyBlobber=ByteArray)
+        self.socketURL = getSocketURL(url)
+        self.rpc = rpc.WebsocketClient(self.socketURL, user, pw, cert=certPath)
+
+    def close(self):
+        """
+        Close the node connection.
+        """
+        self.rpc.close()
+
+    def header(self, blockHash):
+        """
+        Get the header, from the headerDB if possible, otherwise fetch from
+        RPC.
+
+        Args:
+            blockHash (ByteArray): The block header hash.
+
+        Returns:
+            BlockHeader: The block header.
+        """
+        try:
+            return self.headerDB[blockHash]
+        except database.NoValueError:
+            header = self.rpc.getBlockHeader(blockHash, verbose=False)
+            self.headerDB[header.cachedHash()] = header
+            return header
+
+    def blockHash(self, height):
+        """
+        Get the block hash for the specified height, from mainchainDB if
+        possible, otherwise fetch from RPC.
+
+        Args:
+            height (int): The block height.
+
+        Returns:
+            ByteArray: The block hash.
+        """
+        try:
+            return self.mainchainDB[height]
+        except database.NoValueError:
+            return self.rpc.getBlockHash(height)
+
+    def discoverAddresses(self, xPub, idx, gap):
+        """
+        Find all addresses associated with the extended public key, beginning at
+        index and looking up to gap addresses past the last seen address. For
+        example, if startIdx = 5, and gap = 5, and no new addresses are found
+        before 5 + 5 = 10, then to results will be returned. If, on the other
+        hand, a result is found at index 9, addresses will be checked up to
+        index 14. If an address is then found at index 13, result will be
+        checked  up to 18, and so on.
+
+        Args:
+            xPub (ExtendedKey): The extended public key for the external account
+                branch.
+            idx (int): The child index at which to start the scan.
+            gap (int): The maximum number of unseen addresses allowed before
+                quitting the scan.
+
+        Returns:
+            list(int): The discovered address indices.
+        """
+        discovered = []
+        netParams = self.netParams
+        end = idx + gap
+        lastSeen = idx
+
+        its = 0
+        startTime = time.time()
+        while end > idx:
+            its += 1
+            addrs = [
+                deriveChildAddress(xPub, i, netParams) for i in range(idx, end + 1)
+            ]
+            founds = self.rpc.existsAddresses(addrs)
+            for j, found in enumerate(founds):
+                if found:
+                    discovered.append(idx + j)
+                    lastSeen = idx + j
+            idx = end + 1
+            end = lastSeen + 1 + gap
+
+        duration = time.time() - startTime
+        log.debug(
+            f"{its} iterations to discover {len(discovered)} addresses. {duration:.3f} seconds"
+        )
+
+        return discovered
+
+    def syncAccount(self, addrs, outPoints, startHash):
+        """
+        Sync an account.
+
+        Args:
+            addrs list(str): A list of addresses for the transaction filter.
+            outPoints list(msgtx.OutPoint): A list of outpoints for the
+                transaction filter.
+            startHash (ByteArray): Scans will be started at this block. If
+                startHash is not specified, the scan will be started at the root
+                block, which is probably not the genesis block. See syncHeaders
+                documentation for more info on the root block.
+
+        Return:
+            list(RescanBlock): The discovered transactions grouped by block
+                hash.
+        """
+        self.rpc.loadTxFilter(True, addrs, outPoints)
+        maxBlocksPerRescan = 2000
+        mainchain = self.mainchainDB
+
+        startHeader = self.headerDB[startHash]
+        start = startHeader.height
+        tipHeight = mainchain.last()[0]
+        toScan = tipHeight - start + 1
+        log.info(f"synchronizing {toScan} blocks")
+        rescanBlocks = []
+        while start <= tipHeight:
+            blockHashes = [x[1] for x in mainchain[start : start + maxBlocksPerRescan]]
+            rescanBlocks.extend(self.rpc.rescan(blockHashes))
+            start += maxBlocksPerRescan
+
+        return rescanBlocks
+
+    def syncHeaders(self, root):
+        """
+        Synchronize headers after specified blockHash. It is assumed that root
+        block is a mainchain block, a condition easily met if wallets choose
+        their initial root block to be a few blocks before the tip at wallet
+        creation.
+
+        Args:
+            root (ByteArray): The block hash of the root.
+
+        Returns:
+            list(ByteArray): A list of blocks hashes for blocks removed from
+                mainchain.
+        """
+        synced = 0
+        mainchain = self.mainchainDB
+
+        # Get the root header
+        rootHeader = self.header(root)
+        startTime = time.time()
+
+        # Get the current db tip. Store the root block if mainchain bucket is
+        # empty.
+        try:
+            tipHeight, tipHash = mainchain.last()
+
+        except database.NoValueError:
+
+            # Seed the root block.
+            tipHash = rootHeader.cachedHash()
+            tipHeight = rootHeader.height
+            mainchain[tipHeight] = tipHash
+            log.info(f"stored root block at height {tipHeight}")
+            synced = 1
+
+        # Check for missing blocks before the current root.
+        currentRootHeight, currentRootHash = mainchain.first()
+        if currentRootHeight > rootHeader.height:
+            log.info(f"storing a new root block at height {rootHeader.height}")
+            mainchain[rootHeader.height] = rootHeader.cachedHash()
+            synced += 1 + self.syncHeaderRange(rootHeader.height, currentRootHeight - 1)
+
+        # Prune orphans.
+        orphans = []
+        while self.rpc.getBlockHash(tipHeight) != tipHash:
+            orphans.append(tipHash)
+            del mainchain[tipHeight]
+            tipHeight -= 1
+            tipHash = mainchain[tipHeight]
+
+        # Get the current node tip and synchronize the rest.
+        nodeTip = self.rpc.getBestBlock().height
+        if nodeTip > tipHeight:
+            synced += self.syncHeaderRange(tipHeight, nodeTip)
+
+        secs = int(time.time() - startTime)
+        log.info(f"{secs} seconds to sync {synced} block headers")
+
+        height, blockHash = mainchain.last()
+        log.info(f"best block {reversed(blockHash).hex()} at height {nodeTip}")
+
+        return synced, orphans
+
+    def syncHeaderRange(self, start, end):
+        """
+        Store mainchain block headers in the range [start:end), e.g. start is
+        not included.
+
+        Args:
+            start (int): The start height. The block for this height is not
+                synced except in the special cast of start = 0, which does
+                trigger storage of the genesis block.
+            end (int): The last block to sync. This block for this height will
+                be synced.
+
+        Returns:
+            int: The count of headers stored.
+        """
+
+        storage = self.headerDB
+        mainchain = self.mainchainDB
+        synced = 0
+        if start == 0:
+            # store the genesis block
+            genesis = self.header(self.blockHash(0))
+            storage[genesis.cachedHash()] = genesis
+            mainchain[0] = genesis.cachedHash()
+            start = 1
+            synced = 1
+
+        startHash = self.blockHash(start)
+        stopHash = self.blockHash(end)
+        iterationTime = time.time()
+        headers = self.rpc.getHeaders([startHash], stopHash)
+        while headers:
+            synced += len(headers)
+            log.info(f"storing headers from height {start+1} to {start+len(headers)}")
+            storage.batchInsert((header.cachedHash(), header) for header in headers)
+            mainchain.batchInsert(
+                (start + i + 1, header.cachedHash()) for i, header in enumerate(headers)
+            )
+            log.debug(
+                f"{(time.time() - iterationTime) * 1e3:.3f} ms to fetch and insert {len(headers)} headers"
+            )
+            startHash = headers[-1].cachedHash()
+            if startHash == stopHash:
+                break
+            iterationTime = time.time()
+            start += len(headers)
+            headers = self.rpc.getHeaders([startHash], stopHash)
+
+        return synced
+
+
+def deriveChildAddress(branchXPub, i, netParams):
+    """
+    The base-58 encoded address for the i'th child.
+
+    Args:
+        i (int): Child number.
+        netParams (module): Network parameters.
+
+    Returns:
+        str: Child address.
+    """
+    child = branchXPub.child(i)
+    return addrlib.AddressPubKeyHash(
+        crypto.hash160(child.publicKey().serializeCompressed().b),
+        netParams,
+        crypto.STEcdsaSecp256k1,
+    ).string()

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -17,7 +17,7 @@ from decred.crypto import crypto
 from decred.dcr import addrlib
 from decred.util import database, tinyhttp, ws
 from decred.util.encode import ByteArray
-from decred.util.helpers import formatTraceback, getLogger
+from decred.util.helpers import formatTraceback, getLogger, makeWebsocketURL
 
 from . import account, agenda, txscript
 from .wire import msgblock, msgtx, wire
@@ -119,12 +119,7 @@ def getSocketURLs(url):
     Returns:
         string, string: the WebSocket and PubSub URLs.
     """
-    url = urlsplit(url)
-    scheme = "wss" if url.scheme == "https" else "ws"
-    return (
-        urlunsplit((scheme, url.netloc, "/ws", "", "")),
-        urlunsplit((scheme, url.netloc, "/ps", "", "")),
-    )
+    return makeWebsocketURL(url, "ws"), makeWebsocketURL(url, "ps")
 
 
 # TODO: get the full list here.

--- a/decred/decred/dcr/rpc.py
+++ b/decred/decred/dcr/rpc.py
@@ -3467,7 +3467,8 @@ class WebsocketClient(Client):
         Set or add to the current transaction filter.
 
         Args:
-            clear (bool): If true, previous filter will be cleared.
+            clear (bool): If True, previous filter will be cleared, otherwise,
+                the new filter will be combined with the old one.
             addresses list(string): Addresses of interest.
             outPoints list(msgtx.OutPoint): Outputs to look for.
         """
@@ -3492,13 +3493,16 @@ class WebsocketClient(Client):
 
 
 class RescanBlock:
-    """rescan result"""
+    """
+    The result from a rescan. Represents one block with one or more transaction
+    that matched the transaction filter.
+    """
 
     def __init__(self, blockHash, txs):
         """
         Args:
             blockHash (ByteArray): The block hash.
-            txs list(MsgTx): The transactions that matched the rescan filter.
+            txs list(MsgTx): The transactions that matched the tx filter.
         """
         self.hash = blockHash
         self.txs = txs

--- a/decred/decred/dcr/rpc.py
+++ b/decred/decred/dcr/rpc.py
@@ -425,7 +425,7 @@ class Client:
         Returns:
             list(bool): Bool list showing if addresses exist or not.
         """
-        mask = int(self.call("existsaddresses", addresses), 16)
+        mask = ByteArray(self.call("existsaddresses", addresses)).littleEndian().int()
         return [bool(mask & 1 << n) for n in range(len(addresses))]
 
     def existsExpiredTickets(self, txHashes):
@@ -607,7 +607,7 @@ class Client:
 
         Returns:
             GetBlockHeaderVerboseResult or msgblock.BlockHeader: The
-                GetBlockHeaderVerboseResult if vebose or the msgblock.BlockHeader
+                GetBlockHeaderVerboseResult if verbose or the BlockHeader
                 otherwise.
         """
         res = self.call("getblockheader", stringify(blockHash), verbose)
@@ -3461,3 +3461,58 @@ class WebsocketClient(Client):
     def on_error(self, error):
         """Called by ws.Client when an error is encountered."""
         log.error(f"websocket error: {error}")
+
+    def loadTxFilter(self, clear, addresses, outPoints):
+        """
+        Set or add to the current transaction filter.
+
+        Args:
+            clear (bool): If true, previous filter will be cleared.
+            addresses list(string): Addresses of interest.
+            outPoints list(msgtx.OutPoint): Outputs to look for.
+        """
+        ops = [
+            dict(hash=op.hash.rhex(), tree=op.tree, index=op.index) for op in outPoints
+        ]
+        self.call("loadtxfilter", clear, addresses, ops)
+
+    def rescan(self, blockHashes):
+        """
+        Scan the blocks with the currently loaded tx filter.
+
+        Args:
+            blockHashes list(ByteArray): A list of block hashes to scan.
+
+        Returns:
+            list(RescanBlock): A list of results, each representing one block
+                with one or more transactions.
+        """
+        res = self.call("rescan", [h.rhex() for h in blockHashes])
+        return [RescanBlock.parse(blk) for blk in res["discovereddata"]]
+
+
+class RescanBlock:
+    """rescan result"""
+
+    def __init__(self, blockHash, txs):
+        """
+        Args:
+            blockHash (ByteArray): The block hash.
+            txs list(MsgTx): The transactions that matched the rescan filter.
+        """
+        self.hash = blockHash
+        self.txs = txs
+
+    @staticmethod
+    def parse(obj):
+        """
+        Parse the RescanBlock from the decoded RPC response.
+
+        Args:
+            obj (dict): A dictionary from the rescan results 'discovereddata'
+                list.
+        """
+        return RescanBlock(
+            blockHash=reversed(ByteArray(obj["hash"])),
+            txs=[MsgTx.deserialize(hexTX) for hexTX in obj["transactions"]],
+        )

--- a/decred/decred/util/database.py
+++ b/decred/decred/util/database.py
@@ -282,7 +282,16 @@ class Bucket:
             yield decoder(row[0])
             row = cursor.fetchone()
 
-    def _getTuple(self, query):
+    def _getKV(self, query):
+        """
+        A helper to run a parameter-less query intended to return a single row.
+
+        Args:
+            query (str): The query.
+
+        Returns:
+            tuple: The key and value, decoded.
+        """
         cursor = self.conn.cursor()
         cursor.execute(query)
         row = cursor.fetchone()
@@ -292,21 +301,21 @@ class Bucket:
 
     def last(self):
         """
-        Get the highest key in the table. Also returns the value.
+        Get the highest key in the table and its value as a tuple.
 
         Returns:
             tuple: Key and value.
         """
-        return self._getTuple(self.lastQuery)
+        return self._getKV(self.lastQuery)
 
     def first(self):
         """
-        Get the lowest key in the table. Also returns the value.
+        Get the lowest key in the table and its value as a tuple.
 
         Returns:
             tuple: Key and value.
         """
-        return self._getTuple(self.firstQuery)
+        return self._getKV(self.firstQuery)
 
     def clear(self):
         """

--- a/decred/decred/util/encode.py
+++ b/decred/decred/util/encode.py
@@ -234,7 +234,7 @@ class ByteArray:
         return bytearray.__gt__(self.b, decodeBA(a))
 
     def __repr__(self):
-        return "ByteArray(" + str(self.b) + ")"
+        return "ByteArray(" + self.hex() + ")"
 
     def __len__(self):
         return len(self.b)
@@ -286,7 +286,11 @@ class ByteArray:
             self.b[i + j] = v[j]
 
     def __reversed__(self):
+        # TODO: The bytearray shouldn't be necessary here.
         return ByteArray(bytearray(reversed(self.b)))
+
+    def __hash__(self):
+        return hash(bytes(self.b))
 
     def hex(self):
         """
@@ -296,6 +300,15 @@ class ByteArray:
             str: The hex bytes.
         """
         return self.b.hex()
+
+    def rhex(self):
+        """
+        A reversed hexadecimal string representation of the bytes.
+
+        Returns:
+            str: The hex bytes.
+        """
+        return self.__reversed__().hex()
 
     def zero(self):
         """
@@ -346,6 +359,13 @@ class ByteArray:
         b = self[:n]
         self.b = self.b[n:]
         return b
+
+
+def rba(b):
+    """
+    Reversed ByteArray.
+    """
+    return reversed(ByteArray(b))
 
 
 class BuildyBytes(ByteArray):

--- a/decred/decred/util/encode.py
+++ b/decred/decred/util/encode.py
@@ -286,10 +286,10 @@ class ByteArray:
             self.b[i + j] = v[j]
 
     def __reversed__(self):
-        # TODO: The bytearray shouldn't be necessary here.
         return ByteArray(bytearray(reversed(self.b)))
 
     def __hash__(self):
+        """Enables ByteArray to be a dict key."""
         return hash(bytes(self.b))
 
     def hex(self):
@@ -364,6 +364,10 @@ class ByteArray:
 def rba(b):
     """
     Reversed ByteArray.
+
+    Args:
+        b: The intializer. Can be any type accepted by the ByteArray
+            constructor.
     """
     return reversed(ByteArray(b))
 

--- a/decred/decred/util/helpers.py
+++ b/decred/decred/util/helpers.py
@@ -179,7 +179,7 @@ def appDataDir(appName):
 
     # The caller really shouldn't prepend the appName with a period, but
     # if they do, handle it gracefully by stripping it.
-    appName = appName.lstrip()
+    appName = appName.lstrip(".")
     appNameUpper = appName.capitalize()
     appNameLower = appName.lower()
 

--- a/decred/decred/util/helpers.py
+++ b/decred/decred/util/helpers.py
@@ -5,12 +5,16 @@ See LICENSE for details
 """
 
 import calendar
+import configparser
 import logging
 from logging.handlers import RotatingFileHandler
 import os
+import platform
 import sys
 import time
 import traceback
+
+from appdirs import AppDirs
 
 
 def formatTraceback(err):
@@ -135,3 +139,70 @@ def getLogger(name):
     l.setLevel(LogSettings.moduleLevels.get(name, LogSettings.defaultLevel))
     LogSettings.loggers[name] = l
     return l
+
+
+def readINI(path, keys):
+    """
+    Attempt to read the specified keys from the INI-formatted configuration
+    file. All sections will be searched. A dict with discovered keys and
+    values will be returned. If a key is not discovered, it will not be
+    present in the result.
+
+    Args:
+        path (str): The path to the INI configuration file.
+        keys (list(str)): Keys to search for.
+
+    Returns:
+        dict: Discovered keys and values.
+    """
+    config = configparser.ConfigParser()
+    # Need to add a section header since configparser doesn't handle sectionless
+    # INI format.
+    with open(path) as f:
+        config.read_string("[tinydecred]\n" + f.read())  # This line does the trick.
+    res = {}
+    for section in config.sections():
+        for k in config[section]:
+            if k in keys:
+                res[k] = config[section][k]
+    return res
+
+
+def appDataDir(appName):
+    """
+    appDataDir returns an operating system specific directory to be used for
+    storing application data for an application.
+    """
+    if appName == "" or appName == ".":
+        return "."
+
+    # The caller really shouldn't prepend the appName with a period, but
+    # if they do, handle it gracefully by stripping it.
+    appName = appName.lstrip()
+    appNameUpper = appName.capitalize()
+    appNameLower = appName.lower()
+
+    # Get the OS specific home directory.
+    homeDir = os.path.expanduser("~")
+
+    # Fall back to standard HOME environment variable that works
+    # for most POSIX OSes.
+    if homeDir == "":
+        homeDir = os.getenv("HOME")
+
+    opSys = platform.system()
+    if opSys == "Windows":
+        # Windows XP and before didn't have a LOCALAPPDATA, so fallback
+        # to regular APPDATA when LOCALAPPDATA is not set.
+        return AppDirs(appNameUpper, "").user_data_dir
+
+    elif opSys == "Darwin":
+        if homeDir != "":
+            return os.path.join(homeDir, "Library", "Application Support", appNameUpper)
+
+    else:
+        if homeDir != "":
+            return os.path.join(homeDir, "." + appNameLower)
+
+    # Fall back to the current directory if all else fails.
+    return "."

--- a/decred/decred/util/helpers.py
+++ b/decred/decred/util/helpers.py
@@ -13,6 +13,7 @@ import platform
 import sys
 import time
 import traceback
+from urllib.parse import urlsplit, urlunsplit
 
 from appdirs import AppDirs
 
@@ -206,3 +207,19 @@ def appDataDir(appName):
 
     # Fall back to the current directory if all else fails.
     return "."
+
+
+def makeWebsocketURL(baseURL, path):
+    """
+    Turn the HTTP/HTTPS URL into a WS/WSS one.
+
+    Args:
+        url (str): The base URL.
+        path (str): The websocket endpoint path. e.g. path of "ws" will yield
+            URL wss://yourhost.com/ws.
+    Returns:
+        string: the WebSocket URL.
+    """
+    url = urlsplit(baseURL)
+    scheme = "wss" if url.scheme in ("https", "wss") else "ws"
+    return urlunsplit((scheme, url.netloc, f"/{path}", "", ""))

--- a/decred/tests/conftest.py
+++ b/decred/tests/conftest.py
@@ -3,6 +3,7 @@ Copyright (c) 2019, the Decred developers
 See LICENSE for details
 """
 
+import os
 import random
 
 import pytest
@@ -46,3 +47,19 @@ def prepareLogger(request):
 @pytest.fixture(scope="class")
 def registerChain(request):
     chains.registerChain("dcr", None)
+
+
+@pytest.fixture(scope="session")
+def dcrdConfig():
+    dcrdCfgDir = helpers.appDataDir("dcrd")
+    cfgPath = os.path.join(dcrdCfgDir, "dcrd.conf")
+    if not os.path.isfile(cfgPath):
+        return None
+    cfg = helpers.readINI(cfgPath, ["rpcuser", "rpcpass", "rpccert"])
+    assert "rpcuser" in cfg
+    assert "rpcpass" in cfg
+    if "rpccert" not in cfg:
+        cfg["rpccert"] = os.path.join(dcrdCfgDir, "rpc.cert")
+    if "rpclisten" not in cfg:
+        cfg["rpclisten"] = "localhost:9109"
+    return cfg

--- a/decred/tests/integration/dcr/test_blockchain_live.py
+++ b/decred/tests/integration/dcr/test_blockchain_live.py
@@ -1,0 +1,107 @@
+"""
+Copyright (c) 2020, the Decred developers
+See LICENSE for details
+
+Tests use the "http_get_post" fixture in conftest.py .
+"""
+
+import pytest
+
+from decred.dcr.blockchain import LocalNode
+from decred.dcr.nets import mainnet
+from decred.dcr.wire.msgtx import OutPoint
+from decred.util.encode import ByteArray, rba
+
+
+@pytest.fixture
+def node(dcrdConfig, tmp_path):
+    if dcrdConfig is None:
+        return "no configuration found"
+    try:
+        bc = LocalNode(
+            netParams=mainnet,
+            dbPath=tmp_path / "tmp.db",
+            url="https://" + dcrdConfig["rpclisten"],
+            user=dcrdConfig["rpcuser"],
+            pw=dcrdConfig["rpcpass"],
+            certPath=dcrdConfig["rpccert"],
+        )
+    except Exception as e:
+        return e
+    yield bc
+    bc.close()
+
+
+def test_syncAccount(node):
+    # sync a small range of headers.
+    node.syncHeaderRange(400000, 400100)
+
+    # An address from block 400,051, a split transaction to fund a ticket in
+    # block 400,053
+    addr51_0out = "DsSMy2pPZmS7Jd9QoGbzX2DfhAJDqwftWTR"
+    # An address from a previous outpoint being spent in block 400,074. Also
+    # has an output in block 400,053.
+    addr74_0in = "DsbZZXdkA4JKBUK6YbqGmDkgDryKBVdGVD5"
+    # A ticket being spent in transaction 400,025
+    ticket = OutPoint(
+        txHash=rba("60d97229b6229923d6c4c3c6f290fbc507833186f3d1eed1e603e205e0dfe493"),
+        idx=0,
+        tree=1,
+    )
+
+    startHash = node.mainchainDB.first()[1]
+    print("startHash", startHash.rhex())
+
+    scanBlocks = node.syncAccount(
+        addrs=[addr51_0out, addr74_0in], outPoints=[ticket], startHash=startHash,
+    )
+
+    # A mapping of block hashes to number of transactions expected.
+    expTxs = {
+        rba("00000000000000000f9aed681de1bb5ee8d0022ec427d2df526534eab4675c59"): 1,
+        rba("000000000000000015749883c3cf975ea3565695a833e6f44a5caabf8e132ff3"): 1,
+        rba("000000000000000002e6de7314fe8062e1f8abf0711b8cf1f026aff0876466b6"): 2,
+        rba("0000000000000000097661b13a8d4d8d99753445b21f91ab53f66bdbc088338c"): 1,
+    }
+
+    assert len(scanBlocks) == len(expTxs)
+    for block in scanBlocks:
+        assert block.hash in expTxs
+        assert expTxs[block.hash] == len(block.txs)
+
+
+def test_syncHeaders(node):
+    # Get the current best tip.
+    tip = node.rpc.getBestBlock()
+    # Go back 10 block, inclusive of ends, so 11 blocks total to sync.
+    rootHash = node.rpc.getBlockHash(tip.height - 10)
+    rootHeight = node.rpc.getBlock(rootHash).height
+
+    synced, orphans = node.syncHeaders(rootHash)
+    firstHeight, firstHash = node.mainchainDB.first()
+    assert firstHeight == rootHeight
+    assert firstHash == rootHash
+    assert len(node.headerDB) >= 11
+    assert len(node.mainchainDB) >= 11
+    assert synced >= 11
+    assert len(orphans) == 0
+    for height, blockHash in node.mainchainDB.items():
+        assert node.rpc.getBlock(blockHash).height == height
+
+    # Insert a wrong hash at the tip height
+    node.mainchainDB[tip.height] = ByteArray(length=32)
+
+    # Start with an earlier root
+    newRootHash = node.rpc.getBlockHash(rootHeight - 2)
+
+    preSyncHeight = node.mainchainDB.last()[0]
+    synced, orphans = node.syncHeaders(newRootHash)
+    # Expect 3 to be synced. 2 from the beginning, 1 from the reorg.
+    assert synced == node.mainchainDB.last()[0] - preSyncHeight + 3
+    assert len(orphans) == 1
+
+    # Clear the database and test syncing from genesis and more than
+    # maxBlocksPerRescan, just to exercise the paths.
+    node.mainchainDB.clear()
+    node.syncHeaderRange(0, 3000)
+    assert len(node.mainchainDB) == 3000

--- a/decred/tests/integration/dcr/test_blockchain_live.py
+++ b/decred/tests/integration/dcr/test_blockchain_live.py
@@ -71,7 +71,7 @@ def test_syncAccount(node):
 def test_syncHeaders(node):
     # Get the current best tip.
     tip = node.rpc.getBestBlock()
-    # Go back 10 block, inclusive of ends, so 11 blocks total to sync.
+    # Go back 10 blocks, inclusive of ends, so 11 blocks total to sync.
     rootHash = node.rpc.getBlockHash(tip.height - 10)
     rootHeight = node.rpc.getBlock(rootHash).height
 

--- a/decred/tests/integration/dcr/test_blockchain_live.py
+++ b/decred/tests/integration/dcr/test_blockchain_live.py
@@ -1,8 +1,6 @@
 """
 Copyright (c) 2020, the Decred developers
 See LICENSE for details
-
-Tests use the "http_get_post" fixture in conftest.py .
 """
 
 import pytest

--- a/decred/tests/unit/dcr/test_blockchain_unit.py
+++ b/decred/tests/unit/dcr/test_blockchain_unit.py
@@ -1,0 +1,82 @@
+"""
+Copyright (c) 2020, the Decred developers
+See LICENSE for details
+
+Tests use the "http_get_post" fixture in conftest.py .
+"""
+
+import pytest
+
+from decred.crypto import crypto
+from decred.dcr import rpc
+from decred.dcr.blockchain import LocalNode
+from decred.dcr.nets import mainnet
+from decred.util.encode import ByteArray
+
+
+@pytest.fixture
+def node(monkeypatch, tmp_path):
+    existsAddresses = set()
+
+    class TestWsClient:
+        def __init__(self, url, user, pw, cert=None):
+            pass
+
+        def existsAddresses(self, addrs):
+            return [addr in existsAddresses for addr in addrs]
+
+    monkeypatch.setattr(rpc, "WebsocketClient", TestWsClient)
+    bc = LocalNode(
+        netParams=mainnet,
+        dbPath=tmp_path / "tmp.db",
+        url="url",
+        user="user",
+        pw="pass",
+    )
+    bc._existsAddresses = existsAddresses
+    return bc
+
+
+def newExtendedKey():
+    xk = crypto.ExtendedKey.new(
+        ByteArray("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef").b
+    )
+    return xk.deriveCoinTypeKey(mainnet)
+
+
+# A sampling of addresses derived from the newExtendedKey key.
+testAddrs = {
+    3: "DsapZcX3rBfrx85nbWLVoL5PpQAFUJW8ygV",
+    4: "Dscb7StES7pLCgWUVA6jBVpPMdHyKjqSVc4",
+    9: "DsTTd9nYHsE6ygQSYkeCF3Lt9x3gfnzJNNh",
+}
+
+
+def test_discoverAddresses(node):
+    existAddrs = node._existsAddresses
+
+    dcrKey = newExtendedKey()
+
+    # Calling with index 0 and no addresses should return an empty result set.
+    discovered = node.discoverAddresses(dcrKey, 0, 5)
+    assert len(discovered) == 0
+
+    # Stick an address at indexes 3 and 4
+    existAddrs.add(testAddrs[3])
+    existAddrs.add(testAddrs[4])
+    discovered = node.discoverAddresses(dcrKey, 0, 5)
+    assert len(discovered) == 2
+    assert discovered[0] == 3
+    assert discovered[1] == 4
+
+    # Now stick one at 4 + gap = 9
+    existAddrs.add(testAddrs[9])
+    discovered = node.discoverAddresses(dcrKey, 0, 5)
+    assert len(discovered) == 3
+    assert discovered[2] == 9
+
+    # But sticking in just the one at 9 should return nothing still
+    existAddrs.clear()
+    existAddrs.add(testAddrs[9])
+    discovered = node.discoverAddresses(dcrKey, 0, 5)
+    assert len(discovered) == 0

--- a/decred/tests/unit/dcr/test_blockchain_unit.py
+++ b/decred/tests/unit/dcr/test_blockchain_unit.py
@@ -1,8 +1,6 @@
 """
 Copyright (c) 2020, the Decred developers
 See LICENSE for details
-
-Tests use the "http_get_post" fixture in conftest.py .
 """
 
 import pytest

--- a/decred/tests/unit/util/test_database.py
+++ b/decred/tests/unit/util/test_database.py
@@ -54,6 +54,9 @@ def test_database(prepareLogger, randBytes):
         assert intdb.name == "test$inttest"
         intdb[5] = b"asdf"
         assert intdb[5] == b"asdf"
+        intdb[6] = b"jkl;"
+        assert intdb.first() == (5, b"asdf")
+        assert intdb.last() == (6, b"jkl;")
 
         # check uniqueness of keys:
         k = testPairs[0][0]
@@ -80,6 +83,16 @@ def test_database(prepareLogger, randBytes):
         k = testPairs[0][0]
         kidDB[k] = b"some new bytes"
         assert len([key for key in kidDB if key == k]) == 1
+
+        # slice notation
+        sliceDB = db.child("slice", datatypes=("INTEGER", "TEXT"))
+        n = 5
+        for i in range(n):
+            sliceDB[i] = str(i)
+        nums = sliceDB[:n]
+        assert len(nums) == 5
+        assert all(i == int(s) for i, s in nums)
+        assert sliceDB.last()[0] == 4
 
     finally:
         master.close()

--- a/decred/tests/unit/util/test_helpers.py
+++ b/decred/tests/unit/util/test_helpers.py
@@ -5,6 +5,11 @@ See LICENSE for details
 
 import logging
 import os
+import os.path
+from pathlib import Path
+import platform
+
+from appdirs import AppDirs
 
 from decred import DecredError
 from decred.util import helpers
@@ -58,3 +63,116 @@ def test_prepareLogging(tmp_path):
     logger = helpers.getLogger("3")
     assert logger.getEffectiveLevel() == logging.WARNING
     assert logger1.getEffectiveLevel() == logging.NOTSET
+
+
+def test_appDataDir(monkeypatch):
+    """
+    Tests appDataDir to ensure it gives expected results for various operating
+    systems.
+
+    Test adapted from dcrd TestAppDataDir.
+    """
+    # App name plus upper and lowercase variants.
+    appName = "myapp"
+    appNameUpper = appName.capitalize()
+    appNameLower = appName
+
+    # Get the home directory to use for testing expected results.
+    homeDir = Path.home()
+
+    # When we're on Windows, set the expected local and roaming directories
+    # per the environment vars.  When we aren't on Windows, the function
+    # should return the current directory when forced to provide the
+    # Windows path since the environment variables won't exist.
+    winLocal = "."
+    currentOS = platform.system()
+    if currentOS == "Windows":
+        localAppData = os.getenv("LOCALAPPDATA")
+        winLocal = Path(localAppData, appNameUpper)
+    else:
+        # This is kinda cheap, since this is exactly what the function does.
+        # But it's all I got to pass testing when testing OS is not Windows.
+        winLocal = AppDirs(appNameUpper, "").user_data_dir
+
+    # Mac app data directory.
+    macAppData = homeDir / "Library" / "Application Support"
+
+    posixPath = Path(homeDir, "." + appNameLower)
+    macPath = Path(macAppData, appNameUpper)
+
+    """
+    Tests are 3-tuples:
+
+    opSys (str): Operating system.
+    appName (str): The appDataDir argument.
+    want (str): The expected result
+    """
+    tests = [
+        # Various combinations of application name casing, leading
+        # period, operating system, and roaming flags.
+        ("Windows", appNameLower, winLocal),
+        ("Windows", appNameUpper, winLocal),
+        ("Windows", "." + appNameLower, winLocal),
+        ("Windows", "." + appNameUpper, winLocal),
+        ("Linux", appNameLower, posixPath),
+        ("Linux", appNameUpper, posixPath),
+        ("Linux", "." + appNameLower, posixPath),
+        ("Linux", "." + appNameUpper, posixPath),
+        ("Darwin", appNameLower, macPath),
+        ("Darwin", appNameUpper, macPath),
+        ("Darwin", "." + appNameLower, macPath),
+        ("Darwin", "." + appNameUpper, macPath),
+        ("OpenBSD", appNameLower, posixPath),
+        ("OpenBSD", appNameUpper, posixPath),
+        ("OpenBSD", "." + appNameLower, posixPath),
+        ("OpenBSD", "." + appNameUpper, posixPath),
+        ("FreeBSD", appNameLower, posixPath),
+        ("FreeBSD", appNameUpper, posixPath),
+        ("FreeBSD", "." + appNameLower, posixPath),
+        ("FreeBSD", "." + appNameUpper, posixPath),
+        ("NetBSD", appNameLower, posixPath),
+        ("NetBSD", appNameUpper, posixPath),
+        ("NetBSD", "." + appNameLower, posixPath),
+        ("NetBSD", "." + appNameUpper, posixPath),
+        ("unrecognized", appNameLower, posixPath),
+        ("unrecognized", appNameUpper, posixPath),
+        ("unrecognized", "." + appNameLower, posixPath),
+        ("unrecognized", "." + appNameUpper, posixPath),
+        # No application name provided, so expect current directory.
+        ("Windows", "", "."),
+        ("Linux", "", "."),
+        ("Darwin", "", "."),
+        ("OpenBSD", "", "."),
+        ("FreeBSD", "", "."),
+        ("NetBSD", "", "."),
+        ("unrecognized", "", "."),
+        # Single dot provided for application name, so expect current
+        # directory.
+        ("Windows", ".", "."),
+        ("Linux", ".", "."),
+        ("Darwin", ".", "."),
+        ("OpenBSD", ".", "."),
+        ("FreeBSD", ".", "."),
+        ("NetBSD", ".", "."),
+        ("unrecognized", ".", "."),
+    ]
+
+    def testplatform():
+        return opSys
+
+    monkeypatch.setattr(platform, "system", testplatform)
+
+    for opSys, name, want in tests:
+        ret = helpers.appDataDir(name)
+        assert str(want) == str(ret), (opSys, name, want)
+
+    def testexpanduser(s):
+        return ""
+
+    def testgetenv(s):
+        return ""
+
+    opSys = "Linux"
+    monkeypatch.setattr(os.path, "expanduser", testexpanduser)
+    monkeypatch.setattr(os, "getenv", testgetenv)
+    assert helpers.appDataDir(appName) == "."

--- a/decred/tests/unit/wallet/test_accounts.py
+++ b/decred/tests/unit/wallet/test_accounts.py
@@ -7,7 +7,7 @@ import pytest
 
 from decred import DecredError
 from decred.crypto import crypto, rando
-from decred.dcr import account, nets
+from decred.dcr import addrlib, nets
 from decred.util import chains, database, encode
 from decred.wallet import accounts
 
@@ -108,7 +108,7 @@ def test_discover(prepareLogger):
 
     coinExtKey = acctMgr.coinKey(cryptoKey)
     acct2ExtKey = coinExtKey.deriveAccountKey(2).neuter().child(0)
-    acct2Addr5 = account.deriveChildAddress(acct2ExtKey, 5, nets.mainnet)
+    acct2Addr5 = addrlib.deriveChildAddress(acct2ExtKey, 5, nets.mainnet)
     txs[acct2Addr5] = ["tx"]
     acctMgr.discover(cryptoKey)
     assert len(acctMgr.accounts) == 3


### PR DESCRIPTION
Get the basic structure in place for a class called `LocalNode` that is intended for future interchangeability with `DcrdataBlockchain`, though a long ways to go. It uses the new `rpc.WebsocketClient` to access the websocket-only endpoints of the dcrd RPC needed for wallet syncing and chain monitoring. A few basic functions used for syncing accounts are in place to demonstrate how `AccountManager` and `Account` would use `LocalNode`.

Adds some needed functionality to `KeyValueDatabase`. Slice notation is supported, and there are getters for the first and last entries in a table.