### PR TITLE
test: more dcrdata unit tests

### DIFF
--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -152,6 +152,8 @@ class DcrdataClient:
         Args:
             url (string): the URL to a DCRData server, e.g.
                 http://explorer.dcrdata.org/.
+            emitter (function): a function that accepts incoming subscription
+                messages as JSON-decoded dicts as the only parameter.
         """
         url = urlsplit(url)
         # Remove any path.

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -161,7 +161,7 @@ class DcrdataClient:
         _, self.psURL = getSocketURLs(self.baseURL)
         self.ps = None
         self.subscribedAddresses = []
-        self.emitter = emitter
+        self.emitter = emitter if emitter else lambda msg: None
         atexit.register(self.close)
         root = self.root = DcrdataPath()
         self.listEntries = []

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -920,7 +920,6 @@ class DcrdataBlockchain:
         Arg:
             sig (dict or string): The block explorer's notification, decoded.
         """
-        # log.debug("pubsub signal recieved: %s" % repr(sig))
         if sig == WS_DONE:
             return
         sigType = sig["event"]

--- a/decred/tests/unit/dcr/test_dcrdata_unit.py
+++ b/decred/tests/unit/dcr/test_dcrdata_unit.py
@@ -12,8 +12,7 @@ import pytest
 
 from decred import DecredError
 from decred.crypto import opcode
-from decred.dcr import account, agenda, nets, txscript
-from decred.dcr import dcrdata
+from decred.dcr import account, agenda, dcrdata, nets, txscript
 from decred.dcr.dcrdata import (
     DcrdataBlockchain,
     DcrdataClient,
@@ -144,7 +143,6 @@ class MockWebSocketClient:
         self.on_close(self)
 
     def get_emitter(self):
-
         def emitter(msg):
             self.received.append(msg)
 


### PR DESCRIPTION
Improve test coverage for `dcr.dcrdata` up to 97%. Part of #70.

Including proper separation between the sending and receiving parts of `MockWebsocketClient`, and resetting the global `dcrdata._subcounter` (globals are bad).