### PR TITLE
test: unit tests potpourri

### DIFF
--- a/decred/decred/util/chains.py
+++ b/decred/decred/util/chains.py
@@ -63,10 +63,10 @@ def parseCoinType(coinType):
     if isinstance(coinType, str):
         ticker = coinType.lower()
         if ticker not in SymbolIDs:
-            raise DecredError("ticker symbol %d not found" % ticker)
+            raise DecredError(f"ticker symbol {ticker} not found")
         coinType = SymbolIDs[ticker]
     if not isinstance(coinType, int):
-        raise DecredError("unsupported type for coinType %s" % type(coinType))
+        raise DecredError(f"unsupported type for coinType {type(coinType)}")
     return coinType
 
 

--- a/decred/decred/wallet/accounts.py
+++ b/decred/decred/wallet/accounts.py
@@ -147,7 +147,7 @@ class AccountManager:
 
     def dbForAcctIdx(self, idx):
         """
-        Get the databse bucket for the specified index.
+        Get the database bucket for the specified index.
 
         Args:
             idx (int): The account index.

--- a/decred/tests/unit/dcr/test_addrlib.py
+++ b/decred/tests/unit/dcr/test_addrlib.py
@@ -4,6 +4,7 @@ See LICENSE for details
 """
 
 from base58 import b58decode
+import pytest
 
 from decred import DecredError
 from decred.crypto import crypto
@@ -27,7 +28,7 @@ def test_addresses():
     scriptAddress (ByteArray): The expected Address.scriptAddress(), but for
         the address made with make.
     make (func -> str): A function to create a new Address.
-    net (module): The network parameters.
+    netParams (module): The network parameters.
     skipComp (bool): Skip string comparison of decoded address. For
         AddressSecpPubKey, the encoded pubkey is unrecoverable from the
         AddressSecpPubKey.address() string.
@@ -386,3 +387,13 @@ def test_addresses():
         b = addrlib.Address.blob(addr)
         reAddr = addrlib.Address.unblob(b)
         assert addr == reAddr
+
+
+def test_decodeAddressPubKey():
+    decoded = (
+        ByteArray([crypto.STEd25519]) + ByteArray(b"", length=32),
+        ByteArray([crypto.STSchnorrSecp256k1]) + ByteArray(b"", length=32),
+    )
+    for d in decoded:
+        with pytest.raises(NotImplementedError):
+            addrlib.decodeAddressPubKey(decoded, testnet)

--- a/decred/tests/unit/dcr/test_addrlib.py
+++ b/decred/tests/unit/dcr/test_addrlib.py
@@ -396,4 +396,4 @@ def test_decodeAddressPubKey():
     )
     for d in decoded:
         with pytest.raises(NotImplementedError):
-            addrlib.decodeAddressPubKey(decoded, testnet)
+            addrlib.decodeAddressPubKey(d, testnet)

--- a/decred/tests/unit/util/test_chains.py
+++ b/decred/tests/unit/util/test_chains.py
@@ -1,0 +1,21 @@
+"""
+Copyright (c) 2020, the Decred developers
+See LICENSE for details
+"""
+
+import pytest
+
+from decred import DecredError
+from decred.util import chains
+
+
+def test_parseCoinType():
+    with pytest.raises(DecredError):
+        chains.parseCoinType("not_a_coin")
+
+    assert chains.parseCoinType("DCR") == 42
+    assert chains.parseCoinType(42) == 42
+    assert chains.parseCoinType(-1) == -1
+
+    with pytest.raises(DecredError):
+        chains.parseCoinType(None)

--- a/decred/tests/unit/wallet/test_accounts.py
+++ b/decred/tests/unit/wallet/test_accounts.py
@@ -59,6 +59,7 @@ def test_account_manager(prepareLogger):
     tempAcct = acctMgr.addAccount(cryptoKey, "temp")
     assert acctMgr.account(1) == tempAcct
     assert acctMgr.listAccounts() == [acct, tempAcct]
+
     acctMgr.accounts[3] = tempAcct
     del acctMgr.accounts[1]
     with pytest.raises(DecredError):
@@ -71,7 +72,6 @@ def test_account_manager(prepareLogger):
     zeroth = acct.currentAddress()
     b = acctMgr.serialize()
     reAM = accounts.AccountManager.unblob(b.b)
-
     assert acctMgr.coinType == reAM.coinType
     assert acctMgr.netName == reAM.netName
     assert acctMgr.netName == reAM.netName
@@ -79,8 +79,11 @@ def test_account_manager(prepareLogger):
     reAM.load(db, None)
     reAcct = reAM.openAccount(0, cryptoKey)
     reZeroth = reAcct.currentAddress()
-
     assert zeroth == reZeroth
+
+    acctMgr.saveAccount(0)
+    db = acctMgr.dbForAcctIdx(0)
+    assert db.name == "tmp$accts$0"
 
 
 def test_discover(prepareLogger):


### PR DESCRIPTION
Bring test coverage to 100% for `utils.chains`, `wallet.accounts` and `dcr.addrlib`. Part of #70.