### PR TITLE
app: Add relay fee setting

### DIFF
--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -7,6 +7,7 @@ See LICENSE for details
 from decred import DecredError
 from decred.crypto import crypto, opcode
 from decred.dcr import addrlib
+from decred.dcr.txscript import DefaultRelayFeePerKb
 from decred.util import encode, helpers
 from decred.util.encode import BuildyBytes, ByteArray, unblobCheck
 
@@ -801,6 +802,7 @@ class Account:
         self.coinID = BIPID
         self.netID = netID
         self.netParams = nets.parse(netID)
+        self.relayFee = int(DefaultRelayFeePerKb)
         # For external addresses, the cursor can sit on the last seen address,
         # so start the lastSeen at the 0th external address. This is necessary
         # because the currentAddress method grabs the address at the current
@@ -856,6 +858,7 @@ class Account:
             .addData(encode.intToBytes(acct.cursorExt, signed=True))
             .addData(acct.cursorInt)
             .addData(acct.gapLimit)
+            .addData(acct.relayFee)
             .b
         )
 
@@ -863,7 +866,7 @@ class Account:
     def unblob(b):
         """Satisfies the encode.Blobber API"""
         ver, d = encode.decodeBlob(b)
-        unblobCheck("Account", ver, len(d), {0: 8})
+        unblobCheck("Account", ver, len(d), {0: 9})
 
         iFunc = encode.intFromBytes
 
@@ -876,6 +879,7 @@ class Account:
         acct.cursorExt = iFunc(d[5], signed=True)
         acct.cursorInt = iFunc(d[6])
         acct.gapLimit = iFunc(d[7])
+        acct.relayFee = iFunc(d[8])
         return acct
 
     @staticmethod

--- a/decred/decred/wallet/accounts.py
+++ b/decred/decred/wallet/accounts.py
@@ -153,7 +153,7 @@ class AccountManager:
             idx (int): The account's index.
             fee (int): The relay fee in smallest unit/kb.
         """
-        acct = self.acctDB[idx]
+        acct = self.accounts[idx]
         acct.relayFee = fee
         self.acctDB[idx] = acct
 

--- a/decred/decred/wallet/accounts.py
+++ b/decred/decred/wallet/accounts.py
@@ -145,6 +145,18 @@ class AccountManager:
         for acct in self.accounts.values():
             acct.setNode(node)
 
+    def setRelayFee(self, idx, fee):
+        """
+        Save the relay fee for account at index.
+
+        Args:
+            idx (int): The account's index.
+            fee (int): The relay fee in smallest unit/kb.
+        """
+        acct = self.acctDB[idx]
+        acct.relayFee = fee
+        self.acctDB[idx] = acct
+
     def coinKey(self, cryptoKey):
         """
         Decrypt the coin-type extended key.

--- a/tinywallet/tinywallet/screens.py
+++ b/tinywallet/tinywallet/screens.py
@@ -1943,6 +1943,9 @@ class AccountSettingsScreen(Screen):
         self.layout.addStretch(1)
 
     def setFeeLbl(self, fee):
+        """
+        Set the displayed fee as atoms/byte.
+        """
         self.feeLbl.setText(f"{fee//1000} atoms/byte")
 
     def nameChangeClicked(self, e):

--- a/tinywallet/tinywallet/screens.py
+++ b/tinywallet/tinywallet/screens.py
@@ -18,6 +18,7 @@ from decred import DecredError
 from decred.crypto import crypto
 from decred.dcr import constants as DCR, nets
 from decred.dcr.blockchain import LocalNode
+from decred.dcr.txscript import DefaultRelayFeePerKb
 from decred.dcr.vsp import VotingServiceProvider
 from decred.util import chains, database, helpers
 from decred.wallet.wallet import Wallet
@@ -475,7 +476,9 @@ class AccountScreen(Screen):
         self.canGoHome = False
         self.ticketStats = None
         self.balance = None
-        self.settingsScreen = AccountSettingsScreen(self.saveName)
+        self.settingsScreen = AccountSettingsScreen(
+            self.account.relayFee, self.saveName, self.saveRelayFee
+        )
         self.stakeScreen = StakingScreen(acct)
         self.wgt.setFixedSize(
             TinyDialog.maxWidth * 0.9,
@@ -715,6 +718,16 @@ class AccountScreen(Screen):
         self.nameLbl.setText(self.account.name)
         self.assetScreen.doButtons()
         app.home()
+
+    def saveRelayFee(self, relayFee):
+        """
+        Changes and saves the relayFee of the account.
+
+        Args:
+            int: The new relayFee.
+        """
+        self.account.relayFee = relayFee
+        self.acctMgr.saveAccount(self.account.idx)
 
     def stackAndSync(self):
         """
@@ -1832,7 +1845,7 @@ class AccountSettingsScreen(Screen):
     Account settings screen.
     """
 
-    def __init__(self, saveName):
+    def __init__(self, relayFee, saveName, saveRelayFee):
         """
         Args:
             saveName (function): A callback function to be called after the user
@@ -1846,6 +1859,7 @@ class AccountSettingsScreen(Screen):
             TinyDialog.maxHeight * 0.9 - TinyDialog.topMenuHeight,
         )
         self.saveName = saveName
+        self.saveRelayFee = saveRelayFee
 
         gear = SVGWidget("gear", h=20)
         lbl = Q.makeLabel("Account Settings", 22)
@@ -1869,6 +1883,50 @@ class AccountSettingsScreen(Screen):
         bttn.clicked.connect(self.nameChangeClicked)
         grid.addWidget(bttn, row, 1)
 
+        # RELAY FEE
+
+        # Set string constants.
+        self.lowStr = "low"
+        self.defaultStr = "default"
+        self.highStr = "high"
+
+        # Set values that are considered low, default, and high.
+        self.feeRates = {
+            self.lowStr: 4000,
+            self.defaultStr: int(DefaultRelayFeePerKb),
+            self.highStr: 114000,
+        }
+        self.feeLvl = ""
+
+        # Find the current level. Warn if the current level isn't one of the
+        # three.
+        for k, v in self.feeRates.items():
+            if v == relayFee:
+                self.feeLvl = k
+                break
+        else:
+            log.warn(f"non standard relay fee set: {relayFee}")
+
+        # Helper to check the current value.
+        def setChecked(btn):
+            if self.feeLvl == btn.text():
+                btn.setChecked(True)
+
+        row += 1
+        grid.addWidget(Q.makeLabel("Relay Fee", 14, Q.ALIGN_LEFT), row, 0)
+        row += 1
+        btn1 = QtWidgets.QRadioButton(self.lowStr)
+        setChecked(btn1)
+        btn1.toggled.connect(lambda: self.relayFeeChangeClicked(self.lowStr))
+        btn2 = QtWidgets.QRadioButton(self.defaultStr)
+        setChecked(btn2)
+        btn2.toggled.connect(lambda: self.relayFeeChangeClicked(self.defaultStr))
+        btn3 = QtWidgets.QRadioButton(self.highStr)
+        setChecked(btn3)
+        btn3.toggled.connect(lambda: self.relayFeeChangeClicked(self.highStr))
+        wgt, _ = Q.makeRow(btn1, btn2, btn3)
+        grid.addWidget(wgt, row, 0, 1, -1)
+
         self.layout.addStretch(1)
 
     def nameChangeClicked(self, e):
@@ -1881,6 +1939,19 @@ class AccountSettingsScreen(Screen):
             return
         self.nameField.setText("")
         self.saveName(newName)
+
+    def relayFeeChangeClicked(self, feeLvl, e=None):
+        """
+        Qt slot connected to relay fee radio button clicked signal. Changes the
+        relay fee to feeLvl.
+        """
+        if self.feeLvl == feeLvl:
+            return
+        self.feeLvl = feeLvl
+        fee = self.feeRates[feeLvl]
+        self.saveRelayFee(fee)
+        log.info(f"relay fee changed to {fee} atoms/kb")
+        app.appWindow.showSuccess(f"using {feeLvl} fees")
 
 
 class NewAccountScreen(Screen):


### PR DESCRIPTION
Add a relay fee to settings and allow changing. The fee is not yet used.

In an attempt to keep prs small, this only adds the setting, it does not use it.

Related to #28