### PR TITLE
app: Use relayFee setting

### DIFF
--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -1865,7 +1865,7 @@ class Account:
             # signal the balance update
             self.signals.balance(self.calcBalance())
 
-    def sendToAddress(self, value, address, feeRate=None):
+    def sendToAddress(self, value, address):
         """
         Send the value to the address.
 
@@ -1880,7 +1880,7 @@ class Account:
             priv=self.privKeyForAddress, internal=self.nextInternalAddress,
         )
         tx, spentUTXOs, newUTXOs = self.blockchain.sendToAddress(
-            value, address, keysource, self.getUTXOs, feeRate
+            value, address, keysource, self.getUTXOs, self.relayFee
         )
         self.addMempoolTx(tx)
         self.spendUTXOs(spentUTXOs)
@@ -1907,13 +1907,13 @@ class Account:
             spendLimit=int(round(price * qty * 1.1 * 1e8)),  # convert to atoms here
             poolAddress=pi.poolAddress,
             votingAddress=pi.ticketAddress,
-            ticketFee=0,  # use network default
+            ticketFee=DefaultRelayFeePerKb,
             poolFees=pi.poolFees,
             count=qty,
-            txFee=0,  # use network default
+            txFee=self.relayFee,
         )
         txs, spentUTXOs, newUTXOs = self.blockchain.purchaseTickets(
-            keysource, self.getUTXOs, req
+            keysource, self.getUTXOs, req, self.relayFee
         )
         # Add the split transactions
         self.addMempoolTx(txs[0])
@@ -1962,7 +1962,7 @@ class Account:
                 priv=lambda _: self._votingKey,
                 internal=lambda: "",
             )
-            self.blockchain.revokeTicket(tx, keysource, redeemScript)
+            self.blockchain.revokeTicket(tx, keysource, redeemScript, self.relayFee)
 
     def sync(self):
         """

--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -3410,7 +3410,7 @@ def calcMinRequiredTxRelayFee(relayFeePerKb, txSerializeSize):
 
     Args:
         relayFeePerKb (int): The fee in atoms per kilobyte.
-        txSerializeSize int: (Size) of the byte-encoded transaction.
+        txSerializeSize (int): Size of the byte-encoded transaction.
 
     Returns:
         int: Fee in atoms.

--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -154,7 +154,10 @@ P2SHPkScriptSize = 1 + 1 + 20 + 1
 # to maintain reference.
 
 # DefaultRelayFeePerKb is the default minimum relay fee policy for a mempool.
-DefaultRelayFeePerKb = 1e4
+DefaultRelayFeePerKb = int(1e4)
+
+# HighFeeRate is the atoms/kb rate that is considered too high.
+HighFeeRate = DefaultRelayFeePerKb * 1000
 
 # MaxStandardTxSize is the maximum size allowed for transactions that are
 # considered standard and will therefore be relayed and considered for mining.
@@ -2605,7 +2608,7 @@ def paysHighFees(totalInput, tx):
         # Impossible to determine
         return False
 
-    maxFee = calcMinRequiredTxRelayFee(1000 * DefaultRelayFeePerKb, tx.serializeSize())
+    maxFee = calcMinRequiredTxRelayFee(HighFeeRate, tx.serializeSize())
     return fee > maxFee
 
 
@@ -3406,7 +3409,7 @@ def calcMinRequiredTxRelayFee(relayFeePerKb, txSerializeSize):
     pool and relayed.
 
     Args:
-        relayFeePerKb (float): The fee per kilobyte.
+        relayFeePerKb (int): The fee in atoms per kilobyte.
         txSerializeSize int: (Size) of the byte-encoded transaction.
 
     Returns:
@@ -3436,7 +3439,7 @@ def isDustAmount(amount, scriptSize, relayFeePerKb):
     Args:
         amount (int): Atoms.
         scriptSize (int): Byte-size of the script.
-        relayFeePerKb (float): Fees paid per kilobyte.
+        relayFeePerKb (int): Fees paid in atoms per kilobyte.
 
     Returns:
         bool: True if the amount is considered dust.
@@ -3495,7 +3498,7 @@ def isDustOutput(output, relayFeePerKb):
 
     Args:
         output (wire.TxOut): The transaction output.
-        relayFeePerKb: Minimum transaction fee allowable.
+        relayFeePerKb (int): The transaction fee in atoms per kb.
 
     Returns:
         bool: True if output is a dust output.
@@ -3770,7 +3773,7 @@ def stakePoolTicketFee(stakeDiff, relayFee, height, poolFee, subsidyCache, netPa
 
     Args:
         stakeDiff (int): The ticket price.
-        relayFee (int): Transaction fees.
+        relayFee (int): Transaction fees in atoms per kb.
         height (int): Current block height.
         poolFee (int): The pools fee, as percent.
         subsidyCache (calc.SubsidyCache): A subsidy cache.
@@ -3805,8 +3808,8 @@ def stakePoolTicketFee(stakeDiff, relayFee, height, poolFee, subsidyCache, netPa
     # The numerator is (p*10000*s*(v+z)) << 64.
     shift = 64
     s = subsidy
-    v = int(stakeDiff)
-    z = int(relayFee)
+    v = stakeDiff
+    z = relayFee
     num = poolFeeInt
     num *= s
     vPlusZ = v + z

--- a/decred/tests/integration/dcr/test_dcrdata_live.py
+++ b/decred/tests/integration/dcr/test_dcrdata_live.py
@@ -138,7 +138,7 @@ class TestDcrdata:
             )
 
             ticket, spent, newUTXOs = blockchain.purchaseTickets(
-                KeySource(), utxosource, request
+                KeySource(), utxosource, request, 1e4
             )
         finally:
             blockchain.close()
@@ -248,5 +248,5 @@ class TestDcrdata:
                 internal=lambda: "",
             )
             redeemScript = ByteArray(test.redeemScript)
-            revocation = blockchain.revokeTicket(ticket, keysource, redeemScript)
+            revocation = blockchain.revokeTicket(ticket, keysource, redeemScript, 1e4)
             assert test.revocation == revocation.txHex()


### PR DESCRIPTION
app: Use relayFee setting.

~Make relayFee a field of the blockchain and set that field on initiation
and changing.~

Remove the realyFee method from dcrdata and have all relay fees passed
in order to separate functions cleanly. Relay fees now depend upon the
account calling the dcrdata method.

Follow up on #152 
