### PR TITLE
tinywallet: connect to dcrd JSON-RPC server

### DIFF
--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -837,6 +837,7 @@ class Account:
         self.addressDB = None
         # ticketDB is a mapping of txid to tickets (UTXO objects).
         self.ticketDB = None
+        self.synced = False
         # If a database was provided, load it. This would be the case when
         # the account is first created, as opposed to be unblobbed.
         if db is not None:
@@ -935,6 +936,7 @@ class Account:
             signals (Signals): A signaller.
         """
         self.blockchain = blockchain
+        self.node = None
         self.signals = signals
         self.masterDB = db.child("meta")
         self.utxoDB = db.child("utxos", blobber=UTXO)
@@ -959,6 +961,15 @@ class Account:
         if MetaKeys.vsp in self.masterDB:
             apiKeys = encode.unblobStrList(self.masterDB[MetaKeys.vsp])
             self.stakePools = [self.vspDB[apiKey] for apiKey in apiKeys]
+
+    def setNode(self, node):
+        """
+        Set the dcrd connection for the account.
+
+        Args:
+            node (LocalNode): A connected LocalNode.
+        """
+        self.node = node
 
     def unlock(self, cryptoKey):
         """
@@ -2011,6 +2022,7 @@ class Account:
                 f"subscribed to {len(watchAddresses)} addresses for account {self.name}"
             )
         # Signal the new balance.
+        self.synced = True
         signals.balance(self.calcBalance())
 
         return True

--- a/decred/decred/dcr/blockchain.py
+++ b/decred/decred/dcr/blockchain.py
@@ -40,13 +40,30 @@ class LocalNode:
             "headers", blobber=BlockHeader, keyBlobber=ByteArray
         )
         self.socketURL = helpers.makeWebsocketURL(url, "ws")
-        self.rpc = rpc.WebsocketClient(self.socketURL, user, pw, cert=certPath)
+        self.rpc = None
+
+        def connect():
+            self.close()
+            self.rpc = rpc.WebsocketClient(self.socketURL, user, pw, cert=certPath)
+
+        self.connect = connect
+        connect()
 
     def close(self):
         """
         Close the node connection.
         """
-        self.rpc.close()
+        if self.rpc:
+            self.rpc.close()
+
+    def connected(self):
+        """
+        Whether the websocket client appears to be connected.
+
+        Returns:
+            bool: True if connected.
+        """
+        return self.rpc and not self.rpc.closed
 
     def header(self, blockHash):
         """

--- a/decred/decred/dcr/nets/__init__.py
+++ b/decred/decred/dcr/nets/__init__.py
@@ -13,6 +13,13 @@ if "testnet3" in the_nets:
     the_nets["testnet"] = the_nets["testnet3"]
 
 
+DcrdPorts = {
+    mainnet.Name: "9109",
+    testnet.Name: "19109",
+    simnet.Name: "19556",
+}
+
+
 def parse(name):
     """
     Get the network parameters based on the network name.

--- a/decred/decred/dcr/rpc.py
+++ b/decred/decred/dcr/rpc.py
@@ -3380,11 +3380,15 @@ class WebsocketClient(Client):
     def __init__(self, *a, **k):
         super().__init__(*a, **k)
         self.waiters = {}
+        self.lastErr = None
+        self.closed = True
         self.connect()
 
     def connect(self):
         """Connect to the websocket server."""
 
+        self.lastErr = None
+        self.closed = False
         self.ws = ws.Client(
             url=makeWebsocketURL(self.url, "ws"),
             header=[f"{k}: {v}" for k, v in self.headers.items()],
@@ -3435,10 +3439,12 @@ class WebsocketClient(Client):
 
     def on_close(self, ws):
         """Called by ws.Client when the websocket disconnects."""
+        self.closed = True
         log.debug("websocket closing")
 
     def on_error(self, error):
         """Called by ws.Client when an error is encountered."""
+        self.lastErr = error
         log.error(f"websocket error: {error}")
 
     def loadTxFilter(self, clear, addresses, outPoints):

--- a/decred/decred/util/database.py
+++ b/decred/decred/util/database.py
@@ -19,6 +19,10 @@ import threading
 from decred import DecredError
 
 
+TRUE = bytearray([1])
+FALSE = bytearray([0])
+
+
 class NoValueError(DecredError):
     pass
 

--- a/decred/decred/util/ws.py
+++ b/decred/decred/util/ws.py
@@ -47,18 +47,18 @@ class Client(websocket.WebSocketApp):
         user_open = k.pop("on_open", None)
 
         def on_open(ws):
-            initEvent.set()
             if user_open:
                 user_open(ws)
+            initEvent.set()
 
         user_close = k.pop("on_close", None)
 
         def on_close(ws):
             # Some initialization errors won't call on_open, but they will call
             # on_close, so set the initEvent here too.
-            initEvent.set()
             if user_close:
                 user_close(ws)
+            initEvent.set()
 
         super().__init__(cleanURL, on_open=on_open, on_close=on_close, **k)
 

--- a/decred/decred/wallet/accounts.py
+++ b/decred/decred/wallet/accounts.py
@@ -75,6 +75,7 @@ class AccountManager:
 
         self.watchingOnly = False
 
+        self.node = None
         self.acctDB = None
         self.signals = None
         self.accounts = {}
@@ -132,6 +133,17 @@ class AccountManager:
             self.accounts[idx] = acct
             db = self.dbForAcctIdx(idx)
             acct.load(self.dbForAcctIdx(idx), blockchain, self.signals)
+
+    def setNode(self, node):
+        """
+        Set the dcrd connection for the account.
+
+        Args:
+            node (LocalNode): A connected LocalNode.
+        """
+        self.node = node
+        for acct in self.accounts.values():
+            acct.setNode(node)
 
     def coinKey(self, cryptoKey):
         """

--- a/decred/tests/unit/dcr/test_account.py
+++ b/decred/tests/unit/dcr/test_account.py
@@ -562,6 +562,10 @@ class TestAccount:
         assert ticketAddrs[0] == ticketAddr
         assert acct.hasPool()
 
+        # Exercise setNode
+        acct.setNode(1)
+        assert acct.node == 1
+
         # Add a coinbase transaction output to the account.
         coinbase = newCoinbaseTx()
         cbUTXO = account.UTXO("addr", ByteArray(b"id"), 1, height=5, satoshis=int(1e8))

--- a/decred/tests/unit/dcr/test_blockchain_unit.py
+++ b/decred/tests/unit/dcr/test_blockchain_unit.py
@@ -17,6 +17,9 @@ def node(monkeypatch, tmp_path):
     existsAddresses = set()
 
     class TestWsClient:
+
+        closed = False
+
         def __init__(self, url, user, pw, cert=None):
             pass
 
@@ -31,6 +34,7 @@ def node(monkeypatch, tmp_path):
         user="user",
         pw="pass",
     )
+    assert bc.connected()
     bc._existsAddresses = existsAddresses
     return bc
 

--- a/decred/tests/unit/wallet/test_accounts.py
+++ b/decred/tests/unit/wallet/test_accounts.py
@@ -60,6 +60,10 @@ def test_account_manager(prepareLogger):
     assert acctMgr.account(1) == tempAcct
     assert acctMgr.listAccounts() == [acct, tempAcct]
 
+    acctMgr.setNode("node")
+    assert acctMgr.node == "node"
+    assert tempAcct.node == "node"
+
     acctMgr.accounts[3] = tempAcct
     del acctMgr.accounts[1]
     with pytest.raises(DecredError):

--- a/tinywallet/tinywallet/app.py
+++ b/tinywallet/tinywallet/app.py
@@ -7,6 +7,7 @@ A PyQt light wallet.
 """
 
 import os
+from pathlib import Path
 import sys
 
 from PyQt5 import QtCore, QtGui, QtWidgets
@@ -82,7 +83,7 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
         st = self.sysTray = QtWidgets.QSystemTrayIcon(QtGui.QIcon(DCR.FAVICON))
         self.contextMenu = ctxMenu = QtWidgets.QMenu()
         ctxMenu.addAction("minimize").triggered.connect(self.minimizeApp)
-        ctxMenu.addAction("quit").triggered.connect(lambda *a: self.qApp.quit())
+        ctxMenu.addAction("quit").triggered.connect(self.shutdown)
         st.setContextMenu(ctxMenu)
         st.activated.connect(self.sysTrayActivated)
 
@@ -106,7 +107,7 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
         self.settings = self.appDB.child("settings")
         self.loadSettings()
 
-        dcrdataDB = database.KeyValueDatabase(os.path.join(self.netDirectory, "dcr.db"))
+        dcrdataDB = database.KeyValueDatabase(self.assetDirectory("dcr") / "dcrdata.db")
         # The initialized DcrdataBlockchain will not be connected, as that is a
         # blocking operation. It will be called when the wallet is open.
         self.dcrdata = DcrdataBlockchain(
@@ -149,6 +150,11 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
 
         self.initialize()
 
+    def shutdown(self, e=None):
+        """Connected to the context menu "quit" option. Shut down TinyWallet."""
+        self.assetScreen.shutdown()
+        self.qApp.quit()
+
     def initLogging(self):
         """
         Initialize logging for the entire app.
@@ -174,7 +180,6 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
         if os.path.isfile(path):
 
             try:
-                self.dcrdata.connect()
                 w = Wallet(path)
                 self.setWallet(w)
                 self.home(self.assetScreen)
@@ -196,6 +201,12 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
         """
         self.appWindow.stack(self.waitingScreen)
 
+    def notWaiting(self):
+        """
+        Pop the waiting screen.
+        """
+        self.appWindow.pop(self.waitingScreen)
+
     def waitThread(self, f, cb, *a, **k):
         """
         Wait thread shows a waiting screen while the provided function is run
@@ -207,8 +218,6 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
             *args (tuple): Positional arguments passed to f.
             **kwargs (dict): Keyword arguments passed directly to f.
         """
-        cb = cb if cb else lambda *a, **k: None
-        self.waiting()
 
         def run():
             try:
@@ -217,11 +226,12 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
                 err_msg = "waitThread execution error {} failed: {}"
                 self.log.error(err_msg.format(f.__name__, formatTraceback(e)))
             finally:
-                self.appWindow.pop(self.waitingScreen)
+                self.notWaiting()
 
+        self.waiting()
         self.makeThread(run, cb)
 
-    def getPassword(self, f, *args, **kwargs):
+    def getPassword(self, f, prompt="Password"):
         """
         Calls the provided function with a user-provided password string as its
         first argument. Any additional arguments provided to getPassword are
@@ -230,15 +240,60 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
         Args:
             f (func): A function that will receive the user's password
                 and any other provided arguments.
-            *args (tuple): Positional arguments passed to f. The position
-                of the args will be shifted by 1 position with the user's
-                password inserted at position 0.
-            **kwargs (dict): Keyword arguments passed directly to f.
         """
-        self.appWindow.stack(self.pwDialog.withCallback(f, *args, **kwargs))
+        self.appWindow.stack(self.pwDialog.withCallback(f, prompt))
+
+    def withCryptoKey(self, f, cb, prompt="Password"):
+        """
+        Run the provided function, passing the function a single argument, the
+        encryption key, and send the return value of the function to the
+        callback. The function is run in a separate thread with the waiting
+        screen shown, but notWaiting() is routed through a signal and can be
+        called from the thread if desired. The callback function is called in
+        the main thread, so UI updates should be performed in the callback.
+
+        Args:
+            f func(SecretKey): A function of a single argument. The function
+                will be provided the wallet encryption key, and will be run in
+                a separate thread, so UI updates should be properly signaled or
+                restricted to the callback function.
+            cb func(x): A function to receive the return value of f. If an
+                exception is encountered while fetching the key or running the
+                function, cb will receive None.
+        """
+
+        def getCK(pw):
+            try:
+                cryptoKey = self.wallet.cryptoKey(pw)
+                return f(cryptoKey)
+            except Exception as e:
+                self.log.error(
+                    f"error decoding encryption key with provided password: {e}"
+                )
+                self.log.debug(formatTraceback(e))
+                self.appWindow.showError("password error")
+
+        def receivepw(pw):
+            self.appWindow.pop(self.pwDialog)
+            self.waitThread(getCK, cb, pw)
+
+        self.getPassword(receivepw, prompt)
 
     def walletFilename(self):
         return self.settings[DB.wallet].decode()
+
+    def assetDirectory(self, coinID):
+        """
+        Get a directory for asset-specific storage. The directory is a
+        subdirectory of the network directory.
+
+        Args:
+            coinID (int or str): The BIP-0044 asset ID or a ticker symbol.
+        """
+        symbol = chains.IDSymbols[chains.parseCoinType(coinID)]
+        dirPath = Path(self.netDirectory) / symbol
+        helpers.mkdir(dirPath)
+        return dirPath
 
     def sysTrayActivated(self, trigger):
         """
@@ -250,7 +305,7 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
             self.appWindow.show()
             self.appWindow.activateWindow()
 
-    def minimizeApp(self, *a):
+    def minimizeApp(self, e=None):
         """
         Minimizes the application. Because TinyWallet is a system-tray app, the
         program does not halt execution, but the icon is removed from the

--- a/tinywallet/tinywallet/app.py
+++ b/tinywallet/tinywallet/app.py
@@ -260,6 +260,8 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
             cb func(x): A function to receive the return value of f. If an
                 exception is encountered while fetching the key or running the
                 function, cb will receive None.
+            prompt (str): optional. default: "Password". A short message that
+                will be displayed above the password input field.
         """
 
         def getCK(pw):

--- a/tinywallet/tinywallet/config.py
+++ b/tinywallet/tinywallet/config.py
@@ -109,13 +109,6 @@ class DB:
     dcrdon = "dcrdon".encode()
 
 
-DcrdPorts = {
-    nets.mainnet.Name: "9109",
-    nets.testnet.Name: "19109",
-    nets.simnet.Name: "19556",
-}
-
-
 def dcrd(netParams):
     """
     Attempt to fetch the dcrd configuration settings. Values will be parsed for
@@ -142,7 +135,7 @@ def dcrd(netParams):
     if "rpclisten" in dcrdCfg:
         dcrdCfg["rpclisten"] = "https://" + dcrdCfg["rpclisten"]
     else:
-        dcrdCfg["rpclisten"] = f"https://localhost:{DcrdPorts[netParams.Name]}"
+        dcrdCfg["rpclisten"] = f"https://localhost:{nets.DcrdPorts[netParams.Name]}"
     return dcrdCfg
 
 

--- a/tinywallet/tinywallet/config.py
+++ b/tinywallet/tinywallet/config.py
@@ -102,6 +102,48 @@ class DB:
     wallet = "wallet".encode()
     theme = "theme".encode()
     dcrdata = "dcrdata".encode()
+    rpcuser = "rpcuser".encode()
+    rpcpass = "rpcpass".encode()
+    rpccert = "rpccert".encode()
+    rpchost = "rpchost".encode()
+    dcrdon = "dcrdon".encode()
+
+
+DcrdPorts = {
+    nets.mainnet.Name: "9109",
+    nets.testnet.Name: "19109",
+    nets.simnet.Name: "19556",
+}
+
+
+def dcrd(netParams):
+    """
+    Attempt to fetch the dcrd configuration settings. Values will be parsed for
+    'rpcuser', 'rpcpass', 'rpclisten', and 'rpccert'. The setting for 'rpcuser'
+    must be present in the file. If values are not found for 'rpccert' or
+    'rpclisten', default locations are populated.
+
+    Args:
+        netParams (bool): The network parameters.
+
+    Returns:
+        dict or None: The parsed configuration settings.
+    """
+    dcrdCfgDir = helpers.appDataDir("dcrd")
+    cfgPath = os.path.join(dcrdCfgDir, "dcrd.conf")
+    if not os.path.isfile(cfgPath):
+        return {}
+    dcrdCfg = helpers.readINI(cfgPath, ["rpclisten", "rpcuser", "rpcpass", "rpccert"])
+    if "rpcuser" not in dcrdCfg:
+        return None
+    if "rpccert" not in dcrdCfg:
+        dcrdCfg["rpccert"] = os.path.join(dcrdCfgDir, "rpc.cert")
+    # Tinywallet uses the protocol (scheme) of the URL for now.
+    if "rpclisten" in dcrdCfg:
+        dcrdCfg["rpclisten"] = "https://" + dcrdCfg["rpclisten"]
+    else:
+        dcrdCfg["rpclisten"] = f"https://localhost:{DcrdPorts[netParams.Name]}"
+    return dcrdCfg
 
 
 tinyConfig = None

--- a/tinywallet/tinywallet/icons/closed-eye.svg
+++ b/tinywallet/tinywallet/icons/closed-eye.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100"
+   height="100"
+   viewBox="0 0 26.458333 26.458334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (unknown)"
+   sodipodi:docname="closed-eye.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.55"
+     inkscape:cx="60"
+     inkscape:cy="34.285714"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-270.54165)">
+    <path
+       style="fill:#333333;fill-opacity:1;stroke-width:0.19783118"
+       d="m 0.9721495,294.53273 c -0.7168303,-0.71684 -0.50500753,-1.13517 1.7161389,-3.38917 l 2.1118012,-2.14303 -1.2342652,-1.204 c -0.6788462,-0.6622 -1.6334694,-1.8211 -2.1213858,-2.57535 L 0.55731784,283.84984 1.4444386,282.4785 c 2.1384183,-3.30566 5.4255703,-5.50617 9.3456054,-6.25619 1.893957,-0.36237 3.01264,-0.36021 4.945308,0.009 l 1.543319,0.29529 2.693844,-2.66926 c 1.795778,-1.77938 2.836959,-2.66926 3.123121,-2.66926 0.557803,0 1.220595,0.67033 1.220595,1.23447 0,0.6319 -21.8733734,22.50527 -22.5052761,22.50527 -0.2437288,0 -0.6211907,-0.17804 -0.8388054,-0.39566 z m 6.3514492,-8.03253 0.7299421,-0.71277 -0.5140654,-1.11717 C 7.0025835,283.50349 6.8515332,281.87407 7.154081,280.5129 l 0.1480779,-0.6662 -0.7415713,0.54759 c -1.1157634,0.82388 -2.3980663,2.09071 -2.8469401,2.8126 l -0.3997928,0.64295 0.4206826,0.68068 c 0.4012252,0.64919 2.4743346,2.68245 2.7350302,2.68245 0.068246,0 0.452564,-0.32075 0.8540312,-0.71277 z m 4.3078083,-4.30815 c 1.621,-1.63188 1.697366,-2.0078 0.549999,-2.70741 -1.645672,-1.00345 -3.6916708,0.10009 -3.6916708,1.99123 0,1.03208 0.7659742,2.14868 1.4886837,2.17013 0.1115321,0.003 0.8553751,-0.65097 1.6529881,-1.45395 z m -1.105235,9.21515 c -0.8928914,-0.19368 -1.6702166,-0.39894 -1.72739,-0.45611 -0.05718,-0.0572 0.2512392,-0.45079 0.685362,-0.8747 l 0.789314,-0.77075 2.718558,-0.0183 c 2.960774,-0.0199 4.138606,-0.31561 6.303174,-1.58251 1.157538,-0.67748 2.893877,-2.28157 3.458378,-3.19496 l 0.407947,-0.66006 -0.410386,-0.66401 c -0.418475,-0.67711 -1.898245,-2.14269 -2.783235,-2.75655 l -0.490625,-0.34032 0.822454,-0.82245 c 0.785513,-0.78551 0.843096,-0.80881 1.281952,-0.51861 1.419375,0.93857 4.119375,4.28258 4.119375,5.10194 0,0.6189 -1.507374,2.66002 -3.023483,4.09406 -3.204544,3.03107 -7.932211,4.37852 -12.151395,3.4633 z m 1.277778,-3.17192 c -0.276903,-0.10964 0.436866,-0.91866 3.588343,-4.06718 l 3.934002,-3.93032 0.137749,1.00156 c 0.402063,2.92335 -1.358547,5.77107 -4.207933,6.80619 -0.937137,0.34044 -2.811413,0.44346 -3.452161,0.18975 z"
+       id="path1494"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/tinywallet/tinywallet/icons/folder.svg
+++ b/tinywallet/tinywallet/icons/folder.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100"
+   height="100"
+   viewBox="0 0 26.458333 26.458334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (unknown)"
+   sodipodi:docname="folder.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.55"
+     inkscape:cx="22.307692"
+     inkscape:cy="34.285714"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-270.54165)">
+    <path
+       style="fill:#333333;fill-opacity:1;stroke-width:0.19312651"
+       d="m 0.85626191,293.66767 c 0,-0.085 0.0731664,-0.23707 0.16259199,-0.33797 0.089426,-0.10092 1.1432583,-2.81241 2.3418509,-6.02555 l 2.179259,-5.84208 h 9.9954152 9.995415 l -2.319607,6.18005 -2.319608,6.18004 H 10.873921 c -5.5097134,0 -10.01765909,-0.0695 -10.01765909,-0.15449 z m 0.0163796,-10.12949 -0.0163796,-9.80117 H 4.288788 7.721314 l 1.535951,1.54501 1.53595,1.54501 h 5.074102 5.074102 v 1.543 1.54301 l -8.531165,0.0503 -8.5311645,0.0503 -1.495035,6.66287 -1.49503347,6.66286 z"
+       id="path2087"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/tinywallet/tinywallet/icons/open-eye.svg
+++ b/tinywallet/tinywallet/icons/open-eye.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100"
+   height="100"
+   viewBox="0 0 26.458333 26.458334"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (unknown)"
+   sodipodi:docname="open-eye.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.55"
+     inkscape:cx="22.307692"
+     inkscape:cy="34.285714"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-270.54165)">
+    <path
+       style="fill:#333333;fill-opacity:1;stroke-width:0.19540928"
+       d="m 10.624462,291.45015 c -3.8438602,-0.7854 -6.9868907,-2.92135 -9.1249476,-6.2011 l -0.85986238,-1.31902 0.85986238,-1.31902 c 3.6395534,-5.58303 10.4205646,-7.84895 16.5673416,-5.53609 2.608878,0.98164 5.172467,3.0789 6.767075,5.53609 l 0.855985,1.31902 -0.855985,1.31902 c -3.105159,4.78485 -8.856623,7.29483 -14.209469,6.2011 z m 5.255903,-2.3491 c 2.40559,-0.56703 5.55105,-2.68619 6.666829,-4.49156 l 0.419929,-0.67946 -0.394898,-0.63508 c -0.444988,-0.71562 -1.710301,-1.96446 -2.824182,-2.78739 l -0.744588,-0.5501 0.15836,0.56957 c 0.0871,0.31326 0.151626,1.16323 0.143397,1.88882 -0.03952,3.48489 -3.097099,6.24578 -6.6018,5.96121 -3.8335939,-0.31126 -6.4026492,-3.89694 -5.5477571,-7.7431 l 0.1462707,-0.65806 -0.7324988,0.54087 c -1.1021009,0.81381 -2.3687076,2.06513 -2.8120841,2.77818 l -0.3948978,0.63508 0.4199275,0.67946 c 1.0904022,1.76431 4.2534032,3.91991 6.5773026,4.48248 1.521933,0.36842 3.979134,0.37247 5.52069,0.009 z m -3.881645,-5.46744 c 0.315274,-0.16303 0.706612,-0.55437 0.869641,-0.86964 0.849293,-1.64235 -0.244432,-3.52376 -2.048493,-3.52376 -1.8031293,0 -2.8978001,1.88137 -2.0493412,3.52211 0.5559027,1.075 2.0529382,1.47905 3.2281932,0.87129 z"
+       id="path826"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="-56.947848"
+       inkscape:transform-center-y="-21.215864" />
+  </g>
+</svg>

--- a/tinywallet/tinywallet/screens.py
+++ b/tinywallet/tinywallet/screens.py
@@ -225,8 +225,7 @@ class TinyDialog(QtWidgets.QFrame):
         w.setVisible(True)
         self.setIcons(w)
         self.setVisible(True)
-        if hasattr(w, "stacked"):
-            w.stacked()
+        w.stacked()
 
     def pop_(self, screen=None):
         """
@@ -244,8 +243,7 @@ class TinyDialog(QtWidgets.QFrame):
             return
         popped.setVisible(False)
         self.layout.removeWidget(popped)
-        if hasattr(popped, "unstacked"):
-            popped.unstacked()
+        popped.unstacked()
         top.setVisible(True)
         top.runAnimation(FADE_IN_ANIMATION)
         self.setIcons(top)
@@ -261,14 +259,12 @@ class TinyDialog(QtWidgets.QFrame):
         # log.debug("setting home screen")
         for wgt in list(Q.layoutWidgets(self.layout)):
             wgt.setVisible(False)
-            if hasattr(wgt, "unstacked"):
-                wgt.unstacked()
+            wgt.unstacked()
             self.layout.removeWidget(wgt)
         home.setVisible(True)
         home.runAnimation(FADE_IN_ANIMATION)
         self.layout.addWidget(home)
-        if hasattr(home, "stacked"):
-            home.stacked()
+        home.stacked()
         self.setIcons(home)
 
     def setIcons(self, top):
@@ -440,6 +436,20 @@ class Screen(QtWidgets.QWidget):
             self.setGraphicsEffect(effect)
         else:
             self.animations.pop(FADE_IN_ANIMATION, None)
+
+    def stacked(self):
+        """
+        Can be implemented by inheriting classes. Will be called when the
+        screen is stacked.
+        """
+        pass
+
+    def unstacked(self):
+        """
+        Can be implemented by inheriting classes. Will be called when the
+        screen is unstacked.
+        """
+        pass
 
 
 class AccountScreen(Screen):

--- a/tinywallet/tinywallet/screens.py
+++ b/tinywallet/tinywallet/screens.py
@@ -1076,13 +1076,13 @@ class AssetScreen(Screen):
         header.setAlignment(Q.ALIGN_LEFT)
 
         # Indicators for the connection status of dcrdata and dcrd.
-        self.dcrdLight = Q.makeLabel("⚫", 20, color="orange")
+        self.dcrdLight = Q.makeLabel("\u26ab", 20, color="orange")
         lbl = Q.makeLabel("dcrd", 14)
         dcrdBox, lyt = Q.makeRow(self.dcrdLight, lbl)
         lyt.setSpacing(2)
         Q.addClickHandler(dcrdBox, self.stackDcrd)
         dcrdBox.setCursor(QtGui.QCursor(QtCore.Qt.PointingHandCursor))
-        self.dcrdataLight = Q.makeLabel("⚫", 20, color="#76d385")
+        self.dcrdataLight = Q.makeLabel("\u26ab", 20, color="#76d385")
         lbl = Q.makeLabel("dcrdata", 14)
         dcrdataBox, lyt = Q.makeRow(self.dcrdataLight, lbl)
         lyt.setSpacing(2)
@@ -1417,7 +1417,7 @@ class DCRDConfigScreen(Screen):
         grid.addWidget(Q.makeLabel("dcrd URL", 14, Q.ALIGN_LEFT), row, 0, 1, 3)
         grid.addWidget(Q.makeLabel("RPC username", 14, Q.ALIGN_LEFT), row, 3)
         row += 1
-        defaultRpclisten = f"127.0.0.1:{config.DcrdPorts[cfg.netParams.Name]}"
+        defaultRpclisten = f"127.0.0.1:{nets.DcrdPorts[cfg.netParams.Name]}"
         host = nodeConfig.get("rpclisten", defaultRpclisten)
 
         self.rpcListen = QtWidgets.QLineEdit(f"https://{host}")


### PR DESCRIPTION
Adds forms and settings necessary to connect to dcrd. The screen displays either a form to enter server credentials, of if already configured, a screen to turn the connection on or off or to forget the connection.

When the `LocalNode` is connected or disconnected, the `Account`s are informed and store the current `LocalNode`, but don't actually use it yet.

Adds an eye icon used as a button to toggle the echo mode of password fields.

![image](https://user-images.githubusercontent.com/6109680/78508185-84f2a080-774a-11ea-8a2a-ac6148f0b7ed.png)
