### PR TITLE
tests: speed them up by reducing global gap limits

### DIFF
--- a/decred/tests/unit/dcr/test_account.py
+++ b/decred/tests/unit/dcr/test_account.py
@@ -437,13 +437,12 @@ class TestAccount:
             0, pubKeyEncrypted, privKeyEncrypted, "acctName", "mainnet", db, blockchain
         )
 
-    def test_main(self):
+    def test_main(self, monkeypatch):
         """
         Test account functionality.
         """
         # Set up globals for test.
-        origDefaultGapLimit = account.DefaultGapLimit
-        account.DefaultGapLimit = 2
+        monkeypatch.setattr(account, "DefaultGapLimit", 2)
 
         db = KeyValueDatabase(":memory:").child("tmp")
         acct = self.newAccount(db)
@@ -688,9 +687,6 @@ class TestAccount:
         acct.blockchain.revokeTicket = rev
         acct.revokeTickets()
         assert revoked
-
-        # Restore globals.
-        account.DefaultGapLimit = origDefaultGapLimit
 
     def test_readAddrs(self):
         readAddrs = account.Account.readAddrs

--- a/decred/tests/unit/dcr/test_account.py
+++ b/decred/tests/unit/dcr/test_account.py
@@ -441,6 +441,10 @@ class TestAccount:
         """
         Test account functionality.
         """
+        # Set up globals for test.
+        origDefaultGapLimit = account.DefaultGapLimit
+        account.DefaultGapLimit = 2
+
         db = KeyValueDatabase(":memory:").child("tmp")
         acct = self.newAccount(db)
         acct.unlock(self.cryptoKey)
@@ -684,6 +688,9 @@ class TestAccount:
         acct.blockchain.revokeTicket = rev
         acct.revokeTickets()
         assert revoked
+
+        # Restore globals.
+        account.DefaultGapLimit = origDefaultGapLimit
 
     def test_readAddrs(self):
         readAddrs = account.Account.readAddrs

--- a/decred/tests/unit/wallet/test_accounts.py
+++ b/decred/tests/unit/wallet/test_accounts.py
@@ -49,10 +49,9 @@ def test_change_addresses(prepareLogger):
         acct.nextInternalAddress()
 
 
-def test_account_manager(prepareLogger):
+def test_account_manager(monkeypatch, prepareLogger):
     # Set up globals for test.
-    origDefaultGapLimit = account.DefaultGapLimit
-    account.DefaultGapLimit = 2
+    monkeypatch.setattr(account, "DefaultGapLimit", 2)
 
     cryptoKey = rando.newKey()
     db = database.KeyValueDatabase(":memory:").child("tmp")
@@ -93,11 +92,8 @@ def test_account_manager(prepareLogger):
     db = acctMgr.dbForAcctIdx(0)
     assert db.name == "tmp$accts$0"
 
-    # Restore globals.
-    account.DefaultGapLimit = origDefaultGapLimit
 
-
-def test_discover(prepareLogger):
+def test_discover(monkeypatch, prepareLogger):
     cryptoKey = rando.newKey()
     db = database.KeyValueDatabase(":memory:").child("tmp")
     acctMgr = accounts.createNewAccountManager(
@@ -112,10 +108,9 @@ def test_discover(prepareLogger):
     # Set up globals for test.
     origChain = chains.chain("dcr")
     chains.registerChain("dcr", Blockchain)
-    origAccountGapLimit = accounts.ACCOUNT_GAP_LIMIT
-    accounts.ACCOUNT_GAP_LIMIT = 2
-    origDefaultGapLimit = account.DefaultGapLimit
-    account.DefaultGapLimit = 4
+    # Set up globals for test.
+    monkeypatch.setattr(accounts, "ACCOUNT_GAP_LIMIT", 2)
+    monkeypatch.setattr(account, "DefaultGapLimit", 4)
 
     acctMgr.discover(cryptoKey)
     assert len(acctMgr.accounts) == 1
@@ -129,5 +124,3 @@ def test_discover(prepareLogger):
 
     # Restore globals.
     chains.registerChain("dcr", origChain)
-    accounts.ACCOUNT_GAP_LIMIT = origAccountGapLimit
-    account.DefaultGapLimit = origDefaultGapLimit


### PR DESCRIPTION
This fixes #157 (or at least improves it).

Instead of monkeypatching I just reduced global gap limits. The slowest test is down to 3 from 8 seconds (and maybe it can be improved more), several other tests are faster too.

Interestingly, tests get even faster if we don't restore the global gap limits, and they still pass.

(I changed the rather obscure `og` prefix into `orig`.)