### PR TITLE
docs: add more badges to README.md

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,4 +1,4 @@
-name: Check and test both projects
+name: Check and test both packages
 on: [push, pull_request]
 
 jobs:
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        project: [decred, tinywallet]
+        package: [decred, tinywallet]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -20,32 +20,32 @@ jobs:
     - name: Install the poetry tool
       run: |
         pip install poetry
-    - name: Install the ${{ matrix.project }} project and its dependencies
-      working-directory: ${{ format('./{0}/', matrix.project) }}
+    - name: Install the ${{ matrix.package }} package and its dependencies
+      working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |
         poetry install
-    - name: Lint the ${{ matrix.project }} code with black
-      working-directory: ${{ format('./{0}/', matrix.project) }}
+    - name: Lint the ${{ matrix.package }} code with black
+      working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |
         # stop the build if the code was not reformatted by black
         poetry run black --check --diff .
-    - name: Sort ${{ matrix.project }} import lines with isort
-      working-directory: ${{ format('./{0}/', matrix.project) }}
+    - name: Sort ${{ matrix.package }} import lines with isort
+      working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |
         # stop the build if import lines were not sorted by isort
         poetry run isort --check-only --diff --recursive .
-    - name: Lint the ${{ matrix.project }} code with flake8
-      working-directory: ${{ format('./{0}/', matrix.project) }}
+    - name: Lint the ${{ matrix.package }} code with flake8
+      working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |
         # stop the build if there are syntax errors or undefined names
         poetry run flake8 --select=E9,F63,F7,F82 --show-source .
         # exit-zero treats all errors as warnings
         poetry run flake8 --ignore=E203,E221,E261,E731,W503 --exit-zero .
-    - name: Test the ${{ matrix.project }} project with pytest
-      working-directory: ${{ format('./{0}/', matrix.project) }}
+    - name: Test the ${{ matrix.package }} package with pytest
+      working-directory: ${{ format('./{0}/', matrix.package) }}
       run: |
         poetry run pytest ./tests/unit/
-    # - name: Build the ${{ matrix.project }} project
-    #   working-directory: ${{ format('./{0}/', matrix.project) }}
+    # - name: Build the ${{ matrix.package }} package
+    #   working-directory: ${{ format('./{0}/', matrix.package) }}
     #   run: |
     #     poetry build

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ using the [`pip`](https://pip.pypa.io/) command as usual.
 
 ### GitHub
 
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/y/decred/tinydecred)](./graphs/commit-activity)
-[![GitHub contributors](https://img.shields.io/github/contributors/decred/tinydecred)](./graphs/contributors)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/y/decred/tinydecred)](https://github.com/decred/tinydecred/graphs/commit-activity)
+[![GitHub contributors](https://img.shields.io/github/contributors/decred/tinydecred)](https://github.com/decred/tinydecred/graphs/contributors)
 [![GitHub](https://img.shields.io/github/license/decred/tinydecred)](./LICENSE)
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ using the [`pip`](https://pip.pypa.io/) command as usual.
 ## Status
 
 [![Check and test both packages](https://github.com/decred/tinydecred/workflows/Check%20and%20test%20both%20packages/badge.svg)](https://github.com/decred/tinydecred/actions)
-<img src="https://img.shields.io/badge/coverage-98%25-green" alt="Test coverage" title="Test coverage" />
+[![Test coverage](https://img.shields.io/badge/coverage-98%25-green)](./decred/coverage-html.sh)
 
 ### PyPI
 
@@ -24,9 +24,8 @@ using the [`pip`](https://pip.pypa.io/) command as usual.
 
 ### GitHub
 
-<img src="https://img.shields.io/github/commit-activity/y/decred/tinydecred" alt="GitHub commit activity" title="GitHub commit activity" />
-<img src="https://img.shields.io/github/last-commit/decred/tinydecred" alt="GitHub last commit" title="GitHub last commit" />
-<img src="https://img.shields.io/github/contributors/decred/tinydecred" alt="GitHub contributors" title="GitHub contributors" />
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/y/decred/tinydecred)](./graphs/commit-activity)
+[![GitHub contributors](https://img.shields.io/github/contributors/decred/tinydecred)](./graphs/contributors)
 [![GitHub](https://img.shields.io/github/license/decred/tinydecred)](./LICENSE)
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # tinydecred
 
-[![Build Status](https://github.com/decred/tinydecred/workflows/Build%20and%20Test/badge.svg)](https://github.com/decred/tinydecred/actions)
-[![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](https://copyfree.org/)
-
 TinyDecred is a Python 3 toolkit that can be used to integrate
 [Decred](https://decred.org/) into Python projects.
 
@@ -14,6 +11,23 @@ The [`tinywallet`](./tinywallet) package contains a wallet based on the
 
 Each package may be installed from the [Python Package Index](https://pypi.org/)
 using the [`pip`](https://pip.pypa.io/) command as usual.
+
+## Status
+
+[![Check and test both packages](https://github.com/decred/tinydecred/workflows/Check%20and%20test%20both%20packages/badge.svg)](https://github.com/decred/tinydecred/actions)
+![Test coverage](https://img.shields.io/badge/coverage-98%25-green)
+
+### PyPI
+
+[![PyPI release](https://img.shields.io/pypi/v/decred)](https://pypi.org/project/decred/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/decred)](https://docs.python.org/3/)
+
+### GitHub
+
+![GitHub commit activity](https://img.shields.io/github/commit-activity/y/decred/tinydecred)
+![GitHub contributors](https://img.shields.io/github/contributors/decred/tinydecred)
+![GitHub last commit](https://img.shields.io/github/last-commit/decred/tinydecred)
+[![GitHub](https://img.shields.io/github/license/decred/tinydecred)](https://copyfree.org/)
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ using the [`pip`](https://pip.pypa.io/) command as usual.
 ### GitHub
 
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/y/decred/tinydecred)
-![GitHub contributors](https://img.shields.io/github/contributors/decred/tinydecred)
 ![GitHub last commit](https://img.shields.io/github/last-commit/decred/tinydecred)
+![GitHub contributors](https://img.shields.io/github/contributors/decred/tinydecred)
 [![GitHub](https://img.shields.io/github/license/decred/tinydecred)](https://copyfree.org/)
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ using the [`pip`](https://pip.pypa.io/) command as usual.
 ## Status
 
 [![Check and test both packages](https://github.com/decred/tinydecred/workflows/Check%20and%20test%20both%20packages/badge.svg)](https://github.com/decred/tinydecred/actions)
-![Test coverage](https://img.shields.io/badge/coverage-98%25-green)
+<img src="https://img.shields.io/badge/coverage-98%25-green" alt="Test coverage" title="Test coverage" />
 
 ### PyPI
 
@@ -24,10 +24,10 @@ using the [`pip`](https://pip.pypa.io/) command as usual.
 
 ### GitHub
 
-![GitHub commit activity](https://img.shields.io/github/commit-activity/y/decred/tinydecred)
-![GitHub last commit](https://img.shields.io/github/last-commit/decred/tinydecred)
-![GitHub contributors](https://img.shields.io/github/contributors/decred/tinydecred)
-[![GitHub](https://img.shields.io/github/license/decred/tinydecred)](https://copyfree.org/)
+<img src="https://img.shields.io/github/commit-activity/y/decred/tinydecred" alt="GitHub commit activity" title="GitHub commit activity" />
+<img src="https://img.shields.io/github/last-commit/decred/tinydecred" alt="GitHub last commit" title="GitHub last commit" />
+<img src="https://img.shields.io/github/contributors/decred/tinydecred" alt="GitHub contributors" title="GitHub contributors" />
+[![GitHub](https://img.shields.io/github/license/decred/tinydecred)](./LICENSE)
 
 ## Roadmap
 


### PR DESCRIPTION
This adds more badges to `README.md`, and also changes "project" to "package" in the workflow action definition.

The test coverage is currently static, I couldn't find a way to make it dynamic just with GitHub Actions. We'll have to subscribe the repo to a (free for FLOSS code) service like [Coveralls](https://coveralls.io/).