### PR TITLE
multi: use crypto.RIPEMD160_SIZE where needed

### DIFF
--- a/decred/decred/dcr/addrlib.py
+++ b/decred/decred/dcr/addrlib.py
@@ -125,8 +125,10 @@ class AddressPubKeyHash(Address):
 
         super().__init__(netParams)
         pkh_len = len(pkHash)
-        if pkh_len != 20:
-            raise DecredError(f"AddressPubKeyHash expected 20 bytes, got {pkh_len}")
+        if pkh_len != RIPEMD160_SIZE:
+            raise DecredError(
+                f"AddressPubKeyHash expected {RIPEMD160_SIZE} bytes, got {pkh_len}"
+            )
 
         self.sigType = sigType
         self.netID = netParams.PubKeyHashAddrID

--- a/decred/decred/dcr/blockchain.py
+++ b/decred/decred/dcr/blockchain.py
@@ -2,10 +2,8 @@
 Copyright (c) 2020, the Decred developers
 """
 
-
 import time
 
-from decred.crypto import crypto
 from decred.dcr import addrlib, rpc
 from decred.dcr.wire.msgblock import BlockHeader
 from decred.util import database, helpers
@@ -141,7 +139,8 @@ class LocalNode:
 
         duration = time.time() - startTime
         log.debug(
-            f"{its} iterations to discover {len(discovered)} addresses. {duration:.3f} seconds"
+            f"{its} iterations to discover {len(discovered)}"
+            f" addresses. {duration:.3f} seconds"
         )
 
         return discovered
@@ -282,7 +281,8 @@ class LocalNode:
                 (start + i + 1, header.cachedHash()) for i, header in enumerate(headers)
             )
             log.debug(
-                f"{(time.time() - iterationTime) * 1e3:.3f} ms to fetch and insert {len(headers)} headers"
+                f"{(time.time() - iterationTime) * 1e3:.3f} ms"
+                f" to fetch and insert {len(headers)} headers"
             )
             startHash = headers[-1].cachedHash()
             if startHash == stopHash:

--- a/decred/decred/dcr/txscript.py
+++ b/decred/decred/dcr/txscript.py
@@ -1508,7 +1508,8 @@ def checkSSGen(tx):
         or len(firstOutputScript) > SSGenVoteBitsOutputMaxSize
     ):
         raise DecredError(
-            "SSGen votebits output at output index 1 was a NullData (OP_RETURN) push of the wrong size"
+            "SSGen votebits output at output index 1 was"
+            " a NullData (OP_RETURN) push of the wrong size"
         )
 
     # The OP_RETURN output script prefix for voting should conform to the
@@ -1535,9 +1536,8 @@ def checkSSGen(tx):
         # The script should be a OP_SSGEN tagged output.
         if getScriptClass(scrVersion, rawScript) != StakeGenTy:
             raise DecredError(
-                "SSGen tx output at output index {} was not an OP_SSGEN tagged output".format(
-                    i + 2
-                )
+                f"SSGen tx output at output index {i + 2}"
+                " was not an OP_SSGEN tagged output"
             )
 
 
@@ -1752,10 +1752,10 @@ def payToPubKeyHashScript(pkHash):
     Returns:
         ByteArray: The script that pays to the pubkey hash.
     """
-    if len(pkHash) != 20:
+    if len(pkHash) != crypto.RIPEMD160_SIZE:
         raise DecredError(
-            "cannot create script with pubkey hash length %d. expected length 20"
-            % len(pkHash)
+            f"cannot create script with pubkey hash length {pkHash},"
+            f" expected length {crypto.RIPEMD160_SIZE}"
         )
     script = ByteArray(b"")
     script += opcode.OP_DUP
@@ -1777,8 +1777,11 @@ def payToScriptHashScript(scriptHash):
     Returns:
         ByteArray: The script that pays to the script hash.
     """
-    if len(scriptHash) != 20:
-        raise DecredError(f"script hash must be 20 bytes but is {len(scriptHash)}")
+    if len(scriptHash) != crypto.RIPEMD160_SIZE:
+        raise DecredError(
+            f"script hash must be {crypto.RIPEMD160_SIZE}"
+            f" bytes but is {len(scriptHash)}"
+        )
     script = ByteArray("")
     script += opcode.OP_HASH160
     script += addData(scriptHash)
@@ -1818,8 +1821,10 @@ def payToStakePKHScript(pkh, stakeCode):
     Returns:
         ByteArray: The script that pays to the pubkey hash of the address.
     """
-    if len(pkh) != 20:
-        raise DecredError(f"pubkey hash must be 20 bytes but is {len(pkh)}")
+    if len(pkh) != crypto.RIPEMD160_SIZE:
+        raise DecredError(
+            f"pubkey hash must be {crypto.RIPEMD160_SIZE} bytes but is {len(pkh)}"
+        )
     if stakeCode not in (opcode.OP_SSTX, opcode.OP_SSTXCHANGE, opcode.OP_SSRTX):
         raise DecredError(
             f"stake code is not sstx, sstxchange, or ssrtx: {hex(stakeCode)}"
@@ -1846,8 +1851,10 @@ def payToStakeSHScript(sh, stakeCode):
     Returns:
         ByteArray: The script that pays to the script hash of the address.
     """
-    if len(sh) != 20:
-        raise DecredError(f"script hash must be 20 bytes but is {len(sh)}")
+    if len(sh) != crypto.RIPEMD160_SIZE:
+        raise DecredError(
+            f"script hash must be {crypto.RIPEMD160_SIZE} bytes but is {len(sh)}"
+        )
     if stakeCode not in (opcode.OP_SSTX, opcode.OP_SSTXCHANGE, opcode.OP_SSRTX):
         raise DecredError(
             f"stake code is not sstx, sstxchange, or ssrtx: {hex(stakeCode)}"
@@ -1872,9 +1879,8 @@ def multiSigScript(addrs, nRequired):
     """
     if len(addrs) < nRequired:
         raise DecredError(
-            "unable to generate multisig script with {} required signatures when there are only {} public keys available".format(
-                nRequired, len(addrs)
-            )
+            f"unable to generate multisig script with {nRequired} required signatures"
+            f" when there are only {len(addrs)} public keys available"
         )
     script = ByteArray(addInt(nRequired))
     for addr in addrs:

--- a/decred/tests/unit/crypto/test_gcs.py
+++ b/decred/tests/unit/crypto/test_gcs.py
@@ -195,7 +195,8 @@ def test_filter():
     # Test some error paths.
     f = gcs.FilterV2.deserialize(
         ByteArray(
-            "1189af70ad5baf9da83c64e99b18e96a06cd7295a58b324e81f09c85d093f1e33dcd6f40f18cfcbe2aeb771d8390"
+            "1189af70ad5baf9da83c64e99b18e96a06cd7295a58b32"
+            "4e81f09c85d093f1e33dcd6f40f18cfcbe2aeb771d8390"
         )
     )
     member = ByteArray("Alex".encode())
@@ -213,19 +214,22 @@ def test_filter():
     # fmt: off
     # contents1 defines a set of known elements for use in the tests below.
     contents1 = [
-        ByteArray(s.encode()) for s in
-        ("Alex", "Bob", "Charlie", "Dick", "Ed", "Frank", "George", "Harry",
-        "Ilya", "John", "Kevin", "Larry", "Michael", "Nate", "Owen", "Paul",
-        "Quentin")
+        ByteArray(s.encode())
+        for s in (
+            "Alex", "Bob", "Charlie", "Dick", "Ed", "Frank", "George", "Harry", "Ilya",
+            "John", "Kevin", "Larry", "Michael", "Nate", "Owen", "Paul", "Quentin",
+        )
     ]
 
     # contents2 defines a separate set of known elements for use in the tests
     # below.
     contents2 = [
-        ByteArray(s.encode()) for s in
-        ("Alice", "Betty", "Charmaine", "Donna", "Edith", "Faina", "Georgia",
-        "Hannah", "Ilsbeth", "Jennifer", "Kayla", "Lena", "Michelle", "Natalie",
-        "Ophelia", "Peggy", "Queenie")
+        ByteArray(s.encode())
+        for s in (
+            "Alice", "Betty", "Charmaine", "Donna", "Edith", "Faina", "Georgia",
+            "Hannah", "Ilsbeth", "Jennifer", "Kayla", "Lena", "Michelle", "Natalie",
+            "Ophelia", "Peggy", "Queenie",
+        )
     ]
     # fmt: on
 
@@ -255,7 +259,8 @@ def test_filter():
             wantMatches=contents1,
             fixedKey=fixedKey,
             wantBytes=ByteArray(
-                "1189af70ad5baf9da83c64e99b18e96a06cd7295a58b324e81f09c85d093f1e33dcd6f40f18cfcbe2aeb771d8390"
+                "1189af70ad5baf9da83c64e99b18e96a06cd7295a58b32"
+                "4e81f09c85d093f1e33dcd6f40f18cfcbe2aeb771d8390"
             ),
             wantHash=rba(
                 "b616838c6090d3e732e775cc2f336ce0b836895f3e0f22d6c3ee4485a6ea5018"
@@ -268,7 +273,8 @@ def test_filter():
             wantMatches=contents1,
             fixedKey=fixedKey,
             wantBytes=ByteArray(
-                "1189af70ad5baf9da83c64e99b18e96a06cd7295a58b324e81f09c85d093f1e33dcd6f40f18cfcbe2aeb771d8390"
+                "1189af70ad5baf9da83c64e99b18e96a06cd7295a58b32"
+                "4e81f09c85d093f1e33dcd6f40f18cfcbe2aeb771d8390"
             ),
             wantHash=rba(
                 "b616838c6090d3e732e775cc2f336ce0b836895f3e0f22d6c3ee4485a6ea5018"
@@ -281,7 +287,8 @@ def test_filter():
             wantMatches=contents2,
             fixedKey=fixedKey,
             wantBytes=ByteArray(
-                "118d4be5372d2f4731c7e1681aefd23028be12306b4d90701a46b472ee80ad60f9fa86c4d6430cfb495ced604362"
+                "118d4be5372d2f4731c7e1681aefd23028be12306b4d90"
+                "701a46b472ee80ad60f9fa86c4d6430cfb495ced604362"
             ),
             wantHash=rba(
                 "f3028f42909209120c8bf649fbbc5a70fb907d8997a02c2c1f2eef0e6402cb15"

--- a/decred/tests/unit/crypto/test_mnemonic.py
+++ b/decred/tests/unit/crypto/test_mnemonic.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2019, the Decred developers
+Copyright (c) 2019-2020, the Decred developers
 See LICENSE for details
 """
 
@@ -16,22 +16,22 @@ class TestMnemonic(unittest.TestCase):
         tests = [
             (
                 "topmost Istanbul Pluto vagabond treadmill Pacific brackish dictator"
-                " goldfish Medusa afflict bravado chatter revolver Dupont midsummer stopwatch"
-                " whimsical cowbell bottomless",
+                " goldfish Medusa afflict bravado chatter revolver Dupont midsummer"
+                " stopwatch whimsical cowbell bottomless",
                 ByteArray([
                     0xE5, 0x82, 0x94, 0xF2, 0xE9, 0xA2, 0x27, 0x48,
-                    0x6E, 0x8B, 0x06, 0x1B, 0x31, 0xCC, 0x52, 0x8F, 0xD7,
-                    0xFA, 0x3F, 0x19
+                    0x6E, 0x8B, 0x06, 0x1B, 0x31, 0xCC, 0x52, 0x8F,
+                    0xD7, 0xFA, 0x3F, 0x19
                 ]),
             ),
             (
                 "stairway souvenir flytrap recipe adrift upcoming artist positive"
-                " spearhead Pandora spaniel stupendous tonic concurrent transit Wichita lockup"
-                " visitor flagpole escapade",
+                " spearhead Pandora spaniel stupendous tonic concurrent transit Wichita"
+                " lockup visitor flagpole escapade",
                 ByteArray([
                     0xD1, 0xD4, 0x64, 0xC0, 0x04, 0xF0, 0x0F, 0xB5,
-                    0xC9, 0xA4, 0xC8, 0xD8, 0xE4, 0x33, 0xE7, 0xFB, 0x7F,
-                    0xF5, 0x62, 0x56
+                    0xC9, 0xA4, 0xC8, 0xD8, 0xE4, 0x33, 0xE7, 0xFB,
+                    0x7F, 0xF5, 0x62, 0x56
                 ]),
             ),
         ]

--- a/decred/tests/unit/dcr/test_txscript.py
+++ b/decred/tests/unit/dcr/test_txscript.py
@@ -579,8 +579,8 @@ def sstxMismatchedInsOuts():
     return msgtx.MsgTx(
         serType=wire.TxSerializeFull,
         version=1,
-        txIn=[sstxTxIn(),],
-        txOut=[sstxTxOut0(), sstxTxOut1(), sstxTxOut2(), sstxTxOut1(), sstxTxOut2(),],
+        txIn=[sstxTxIn()],
+        txOut=[sstxTxOut0(), sstxTxOut1(), sstxTxOut2(), sstxTxOut1(), sstxTxOut2()],
         lockTime=0,
         expiry=0,
         cachedHash=None,


### PR DESCRIPTION
Also shorten a number of lines, and other assorted cleanup. From a PR [comment](https://github.com/decred/tinydecred/pull/150#discussion_r407512236).