### PR TITLE
app: Check for assetScreen on shutdown.

### DIFF
--- a/tinywallet/tinywallet/app.py
+++ b/tinywallet/tinywallet/app.py
@@ -153,7 +153,8 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
         """
         Connected to the context menu "quit" option. Shut down TinyWallet.
         """
-        self.assetScreen.shutdown()
+        if hasattr(self, "assetScreen"):
+            self.assetScreen.shutdown()
         self.qApp.quit()
 
     def initLogging(self):

--- a/tinywallet/tinywallet/app.py
+++ b/tinywallet/tinywallet/app.py
@@ -76,6 +76,7 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
         self.cfg = config.load()
         self.log = self.initLogging()
         self.wallet = None
+        self.assetScreen = None
         # trackedCssItems are CSS-styled elements to be updated if dark mode is
         # enabled/disabled.
         self.trackedCssItems = []
@@ -153,7 +154,7 @@ class TinyWallet(QtCore.QObject, Q.ThreadUtilities):
         """
         Connected to the context menu "quit" option. Shut down TinyWallet.
         """
-        if hasattr(self, "assetScreen"):
+        if self.assetScreen:
             self.assetScreen.shutdown()
         self.qApp.quit()
 


### PR DESCRIPTION
Otherwise you may call shutdown on a non-existant attribute.

If you start up the app and close it without making a wallet, you will see this error currently:
```
Traceback (most recent call last):
  File "tinywallet/app.py", line 155, in shutdown
    if self.assetScreen is not None:
AttributeError: 'TinyWallet' object has no attribute 'assetScreen'
```