### PR TITLE
multi: fix a number of unrelated issues

### DIFF
--- a/decred/decred/crypto/secp256k1/curve.py
+++ b/decred/decred/crypto/secp256k1/curve.py
@@ -199,29 +199,48 @@ def generateKey():
     return PrivateKey(curve, b, x, y)
 
 
-class KoblitzCurve:
-    """
-    KoblitzCurve provides a secp256k1 Koblitz curve implementation.
-    """
+def fromHex(hx):
+    return int(hx, 16)
 
-    def __init__(
-        self, P, N, B, Gx, Gy, BitSize, H, q, byteSize, lambda_, beta, a1, b1, a2, b2
-    ):
-        self.P = P
-        self.N = N
-        self.B = B
-        self.Gx = Gx
-        self.Gy = Gy
-        self.BitSize = BitSize
-        self.H = H
-        self.q = q
-        self.byteSize = byteSize
-        self.lambda_ = lambda_
-        self.beta = beta
-        self.a1 = a1
-        self.b1 = b1
-        self.a2 = a2
-        self.b2 = b2
+
+class Curve:
+    def __init__(self):
+        bitSize = 256
+        p = fromHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F")
+        self.P = p
+        self.N = fromHex(
+            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+        )
+        self.B = fromHex(
+            "0000000000000000000000000000000000000000000000000000000000000007"
+        )
+        self.Gx = fromHex(
+            "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+        )
+        self.Gy = fromHex(
+            "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8"
+        )
+        self.BitSize = bitSize
+        self.H = 1
+        self.q = (p + 1) // 4
+        # Provided for convenience since this gets computed repeatedly.
+        self.byteSize = bitSize / 8
+        # Next 6 constants are from Hal Finney's bitcointalk.org post:
+        # https://bitcointalk.org/index.php?topic=3238.msg45565#msg45565
+        # May he rest in peace.
+        #
+        # They have also been independently derived from the code in the
+        # EndomorphismVectors function in gensecp256k1.go.
+        self.lambda_ = fromHex(
+            "5363AD4CC05C30E0A5261C028812645A122E22EA20816678DF02967C1B23BD72"
+        )
+        self.beta = FieldVal.fromHex(
+            "7AE96A2B657C07106E64479EAC3434E99CF0497512F58995C1396C28719501EE"
+        )
+        self.a1 = fromHex("3086D221A7D46BCDE86C90E49284EB15")
+        self.b1 = fromHex("-E4437ED6010E88286F547FA90ABFE4C3")
+        self.a2 = fromHex("114CA50F7A8E2F3F657C1108D9D44CFD8")
+        self.b2 = fromHex("3086D221A7D46BCDE86C90E49284EB15")
 
     def scalarBaseMult(self, k):
         """
@@ -982,57 +1001,6 @@ class KoblitzCurve:
 
         # Convert the field values for the now affine point to integers.
         return ByteArray(x.bytes()).int(), ByteArray(y.bytes()).int()
-
-
-def fromHex(hx):
-    """
-    fromHex converts the passed hex string into an integer.  This is only
-    meant for the hard-coded constants so errors in the source code can be
-    detected. It will (and must) only be called for initialization purposes.
-    """
-    return int(hx, 16)
-
-
-class Curve(KoblitzCurve):
-    def __init__(self):
-        bitSize = 256
-        p = fromHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F")
-        super().__init__(
-            P=p,
-            N=fromHex(
-                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
-            ),
-            B=fromHex(
-                "0000000000000000000000000000000000000000000000000000000000000007"
-            ),
-            Gx=fromHex(
-                "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
-            ),
-            Gy=fromHex(
-                "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8"
-            ),
-            BitSize=bitSize,
-            H=1,
-            q=(p + 1) // 4,
-            # Provided for convenience since this gets computed repeatedly.
-            byteSize=bitSize / 8,
-            # Next 6 constants are from Hal Finney's bitcointalk.org post:
-            # https://bitcointalk.org/index.php?topic=3238.msg45565#msg45565
-            # May he rest in peace.
-            #
-            # They have also been independently derived from the code in the
-            # EndomorphismVectors function in gensecp256k1.go.
-            lambda_=fromHex(
-                "5363AD4CC05C30E0A5261C028812645A122E22EA20816678DF02967C1B23BD72"
-            ),
-            beta=FieldVal.fromHex(
-                "7AE96A2B657C07106E64479EAC3434E99CF0497512F58995C1396C28719501EE"
-            ),
-            a1=fromHex("3086D221A7D46BCDE86C90E49284EB15"),
-            b1=fromHex("-E4437ED6010E88286F547FA90ABFE4C3"),
-            a2=fromHex("114CA50F7A8E2F3F657C1108D9D44CFD8"),
-            b2=fromHex("3086D221A7D46BCDE86C90E49284EB15"),
-        )
 
     def bigAffineToField(self, x, y):
         """

--- a/decred/decred/dcr/account.py
+++ b/decred/decred/dcr/account.py
@@ -1833,7 +1833,7 @@ class Account:
         tx = self.blockchain.tx(txid)
         self.addTxid(addr, tx.txid())
 
-        matches = False
+        matches = 0
         # scan the inputs for any spends.
         for txin in tx.txIn:
             op = txin.previousOutPoint

--- a/decred/decred/dcr/dcrdata.py
+++ b/decred/decred/dcr/dcrdata.py
@@ -429,7 +429,7 @@ class DcrdataBlockchain:
         self.heightMap = db.child("height", datatypes=("INTEGER", "BLOB"))
         self.headerDB = db.child("header", blobber=msgblock.BlockHeader)
         self.txBlockMap = db.child("blocklink")
-        self.tipHeight = None
+        self.tipHeight = -1
         self.subsidyCache = txscript.SubsidyCache(netParams)
         self.addrSubscribers = {}
         self.blockSubscribers = []

--- a/decred/decred/dcr/wire/msgtx.py
+++ b/decred/decred/dcr/wire/msgtx.py
@@ -458,7 +458,7 @@ class MsgTx:
         s("version", self.version)
         for i, txIn in enumerate(self.txIn):
             s("txIn {}".format(i), "")
-            s("previousOutPoint".format(i), "", 1)
+            s("previousOutPoint", "", 1)
             s("txid", txIn.previousOutPoint.txid(), 2)
             s("idx", txIn.previousOutPoint.index, 2)
             s("tree", txIn.previousOutPoint.tree, 2)

--- a/decred/decred/util/helpers.py
+++ b/decred/decred/util/helpers.py
@@ -20,7 +20,7 @@ from appdirs import AppDirs
 
 def formatTraceback(err):
     """
-    Format a traceback for an error.
+    Format a traceback for an error so that it can go into logs.
 
     Args:
         err (BaseException): The error the traceback is extracted from.
@@ -29,7 +29,7 @@ def formatTraceback(err):
         str: The __str__() of the error, followed by the standard formatting
             of the traceback on the following lines.
     """
-    return f"{err}\nTraceback:\n{traceback.extract_tb(err.__traceback__)}"
+    return "".join(traceback.format_exception(None, err, err.__traceback__))
 
 
 def mkdir(path):

--- a/decred/decred/util/helpers.py
+++ b/decred/decred/util/helpers.py
@@ -29,7 +29,7 @@ def formatTraceback(err):
         str: The __str__() of the error, followed by the standard formatting
             of the traceback on the following lines.
     """
-    return f"{err}\nTraceback:\n{traceback.print_tb(err.__traceback__)}"
+    return f"{err}\nTraceback:\n{traceback.extract_tb(err.__traceback__)}"
 
 
 def mkdir(path):
@@ -117,7 +117,7 @@ def prepareLogging(filepath=None, logLvl=logging.INFO, lvlMap=None):
             maxBytes=5 * 1024 * 1024,
             backupCount=2,
             encoding=None,
-            delay=0,
+            delay=False,
         )
         fileHandler.setFormatter(log_formatter)
         LogSettings.root.addHandler(fileHandler)

--- a/decred/tests/unit/util/test_helpers.py
+++ b/decred/tests/unit/util/test_helpers.py
@@ -17,7 +17,7 @@ from decred.util import helpers
 
 def test_formatTraceback():
     # Cannot actually raise an error because pytest intercepts it.
-    assert helpers.formatTraceback(DecredError("errmsg")) == "errmsg\nTraceback:\nNone"
+    assert helpers.formatTraceback(DecredError("errmsg")) == "errmsg\nTraceback:\n[]"
 
 
 def test_mkdir(tmp_path):

--- a/decred/tests/unit/util/test_helpers.py
+++ b/decred/tests/unit/util/test_helpers.py
@@ -17,7 +17,9 @@ from decred.util import helpers
 
 def test_formatTraceback():
     # Cannot actually raise an error because pytest intercepts it.
-    assert helpers.formatTraceback(DecredError("errmsg")) == "errmsg\nTraceback:\n[]"
+    assert (
+        helpers.formatTraceback(DecredError("errmsg")) == "decred.DecredError: errmsg\n"
+    )
 
 
 def test_mkdir(tmp_path):

--- a/tinywallet/tinywallet/screens.py
+++ b/tinywallet/tinywallet/screens.py
@@ -1134,7 +1134,7 @@ class AssetScreen(Screen):
         except DecredError as e:
             msg = "failed to connect to dcrdata"
             app.appWindow.showError(msg)
-            log.warning(f"{msg}: {formatTraceback(e)}")
+            log.warning(f"{msg}\n{formatTraceback(e)}")
             return
 
         # Check for a dcrd configuration. If found, request the cryptoKey so the

--- a/tinywallet/tinywallet/screens.py
+++ b/tinywallet/tinywallet/screens.py
@@ -1132,7 +1132,9 @@ class AssetScreen(Screen):
         try:
             app.dcrdata.connect()
         except DecredError as e:
-            app.appWindow.showError(f"failed to connect to dcrdata: {e}")
+            msg = "failed to connect to dcrdata"
+            app.appWindow.showError(msg)
+            log.warning(f"{msg}: {formatTraceback(e)}")
             return
 
         # Check for a dcrd configuration. If found, request the cryptoKey so the


### PR DESCRIPTION
This fixes a number of unrelated issues, grouped for convenience.

It merges the `KoblitzCurve` and `Curve` classes in `crypto.secp256k1.curve`. While `Curve` is a subclass of `KoblitzCurve`, `KoblitzCurve` uses methods in `Curve`, so they're not really independent. And `KoblitzCurve` is never used directly anyway.

The other issues are explained by comments in the diff.