### PR TITLE
multi: add type hints to helpers.py and tinyhttp.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ prof/
 .venv/
 .mypy_cache/
 __pycache__/
+.mypy_cache/
 .pytest_cache
 .coverage
 *.c

--- a/decred/decred/crypto/crypto.py
+++ b/decred/decred/crypto/crypto.py
@@ -9,9 +9,9 @@ Cryptographic functions.
 import hashlib
 import hmac
 
-from base58 import b58decode, b58encode
-from blake256.blake256 import blake_hash
-import nacl.secret
+from base58 import b58decode, b58encode  # type: ignore
+from blake256.blake256 import blake_hash  # type: ignore
+import nacl.secret  # type: ignore
 
 from decred import DecredError
 from decred.util import encode

--- a/decred/decred/crypto/gcs.py
+++ b/decred/decred/crypto/gcs.py
@@ -3,8 +3,8 @@ Copyright (c) 2020, The Decred developers
 See LICENSE for details
 """
 
-from blake256.blake256 import blake_hash
-from nacl.hash import siphash24
+from blake256.blake256 import blake_hash  # type: ignore
+from nacl.hash import siphash24  # type: ignore
 
 from decred import DecredError
 from decred.dcr.wire import wire

--- a/decred/decred/dcr/addrlib.py
+++ b/decred/decred/dcr/addrlib.py
@@ -7,7 +7,7 @@ Cryptographic functions.
 """
 
 
-from base58 import b58encode
+from base58 import b58encode  # type: ignore
 
 from decred import DecredError
 from decred.crypto.crypto import (

--- a/decred/decred/dcr/nets/__init__.py
+++ b/decred/decred/dcr/nets/__init__.py
@@ -8,7 +8,7 @@ from decred import DecredError
 from . import mainnet, simnet, testnet
 
 
-the_nets = {n.Name: n for n in (mainnet, testnet, simnet)}
+the_nets = {n.Name: n for n in (mainnet, testnet, simnet)}  # type: ignore
 if "testnet3" in the_nets:
     the_nets["testnet"] = the_nets["testnet3"]
 

--- a/decred/decred/util/helpers.py
+++ b/decred/decred/util/helpers.py
@@ -10,12 +10,12 @@ import logging
 from logging import Logger
 from logging.handlers import RotatingFileHandler
 import os
-from pathlib import PosixPath
+from pathlib import Path
 import platform
 import sys
 import time
 import traceback
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, Optional, Union
 from urllib.parse import urlsplit, urlunsplit
 
 from appdirs import AppDirs  # type: ignore
@@ -35,7 +35,7 @@ def formatTraceback(err: Exception) -> str:
     return "".join(traceback.format_exception(None, err, err.__traceback__))
 
 
-def mkdir(path: PosixPath) -> bool:
+def mkdir(path: Path) -> bool:
     """
     Create the directory if it doesn't exist. Uses os.path .
 
@@ -91,7 +91,7 @@ LogSettings.root.setLevel(logging.NOTSET)
 
 
 def prepareLogging(
-    filepath: Optional[PosixPath] = None,
+    filepath: Union[Path, str, None] = None,
     logLvl: int = logging.INFO,
     lvlMap: Optional[Dict[str, int]] = None,
 ) -> None:
@@ -152,7 +152,7 @@ def getLogger(name: str) -> Logger:
     return l
 
 
-def readINI(path: str, keys: Iterable[str]) -> Optional[Dict[str, str]]:
+def readINI(path: str, keys: Iterable[str]) -> Dict[str, str]:
     """
     Attempt to read the specified keys from the INI-formatted configuration
     file. All sections will be searched. A dict with discovered keys and

--- a/decred/decred/util/helpers.py
+++ b/decred/decred/util/helpers.py
@@ -56,8 +56,8 @@ def mktime(year: int, month: Optional[int] = None, day: Optional[int] = None) ->
 
     Args:
         year: the year.
-        month, optional: the month.
-        day, optional: the day.
+        month: the month.
+        day: the day.
 
     Returns:
         The UNIX epoch time.

--- a/decred/decred/util/helpers.py
+++ b/decred/decred/util/helpers.py
@@ -206,7 +206,7 @@ def appDataDir(appName: str) -> str:
     # Fall back to standard HOME environment variable that works
     # for most POSIX OSes.
     if homeDir == "":
-        homeDir = os.getenv("HOME") or ""
+        homeDir = os.getenv("HOME", "")
 
     opSys = platform.system()
     if opSys == "Windows":

--- a/decred/decred/util/tinyhttp.py
+++ b/decred/decred/util/tinyhttp.py
@@ -1,11 +1,14 @@
 """
 Copyright (c) 2019, Brian Stafford
+Copyright (c) 2019-2020, The Decred developers
 See LICENSE for details
 
-DcrdataClient.endpointList() for available enpoints.
+See DcrdataClient.endpointList() for available enpoints.
 """
 
 import json
+from ssl import SSLContext
+from typing import Dict, List, Optional, Union
 from urllib.parse import urlencode
 import urllib.request as urlrequest
 
@@ -14,16 +17,54 @@ from decred import DecredError
 from .helpers import formatTraceback
 
 
-def get(url, **kwargs):
+def get(url: str, **kwargs) -> Union[Dict[str, str], List[int], str]:
+    """
+    A convenience function to make a GET HTTP request.
+
+    Args:
+        url: The URL to connect to.
+        kwargs: Other arguments to pass to the request function.
+    """
     return request(url, **kwargs)
 
 
-def post(url, data, **kwargs):
+def post(
+    url: str, data: Dict[str, str], **kwargs
+) -> Union[Dict[str, str], List[int], str]:
+    """
+    A convenience function to make a POST HTTP request.
+
+    Args:
+        url: The URL to connect to.
+        data: The data to send.
+        kwargs: Other arguments to pass to the request function.
+    """
     return request(url, data, **kwargs)
 
 
-def request(url, postData=None, headers=None, urlEncode=False, context=None):
-    # GET method used when encoded data is None.
+def request(
+    url: str,
+    postData: Optional[Dict[str, str]] = None,
+    headers: Optional[Dict[str, str]] = None,
+    urlEncode: Optional[bool] = False,
+    context: Optional[SSLContext] = None,
+) -> Union[Dict[str, str], List[int], str]:
+    """
+    Make an HTTP request and try to decode the payload as JSON. If an error
+    happens while decoding, return the raw payload.
+
+    If any postData is passed, the POST method is used, otherwise the GET one.
+
+    Args:
+        url: The URL to connect to.
+        postData: The data to POST, if any.
+        headers: Any custom headers to add to the request.
+        urlEncode: Whether to urlencode the postData.
+        context: An SSLContext used to encrypt the request.
+
+    Returns:
+        The decoded JSON data or the raw payload.
+    """
     encoded = None
     if postData:
         if urlEncode:

--- a/decred/decred/util/tinyhttp.py
+++ b/decred/decred/util/tinyhttp.py
@@ -8,7 +8,7 @@ See DcrdataClient.endpointList() for available enpoints.
 
 import json
 from ssl import SSLContext
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlencode
 import urllib.request as urlrequest
 
@@ -17,7 +17,10 @@ from decred import DecredError
 from .helpers import formatTraceback
 
 
-def get(url: str, **kwargs) -> Union[Dict[str, str], List[int], str]:
+JSONType = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
+
+
+def get(url: str, **kwargs) -> JSONType:
     """
     A convenience function to make a GET HTTP request.
 
@@ -28,9 +31,7 @@ def get(url: str, **kwargs) -> Union[Dict[str, str], List[int], str]:
     return request(url, **kwargs)
 
 
-def post(
-    url: str, data: Dict[str, str], **kwargs
-) -> Union[Dict[str, str], List[int], str]:
+def post(url: str, data: Dict[str, str], **kwargs) -> JSONType:
     """
     A convenience function to make a POST HTTP request.
 
@@ -48,7 +49,7 @@ def request(
     headers: Optional[Dict[str, str]] = None,
     urlEncode: Optional[bool] = False,
     context: Optional[SSLContext] = None,
-) -> Union[Dict[str, str], List[int], str]:
+) -> JSONType:
     """
     Make an HTTP request and try to decode the payload as JSON. If an error
     happens while decoding, return the raw payload.

--- a/decred/decred/util/ws.py
+++ b/decred/decred/util/ws.py
@@ -5,7 +5,7 @@ See LICENSE for details
 
 import threading
 
-import websocket
+import websocket  # type: ignore
 
 
 class Client(websocket.WebSocketApp):

--- a/decred/pyproject.toml
+++ b/decred/pyproject.toml
@@ -29,6 +29,7 @@ base58 = "^2.0.0"
 blake256 = "^0.1.1"
 pynacl = "^1.3.0"
 websocket_client = "^0.57.0"
+pytest-monkeytype = "^1.0.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3"
@@ -41,6 +42,7 @@ websocket-server = "^0.4"
 pytest-benchmark = "^3.2.3"
 pytest-profiling = "^1.7.0"
 Cython = "^0.29.16"
+mypy = "^0.770"
 
 [tool.isort]
 atomic = "true"

--- a/decred/tests/unit/util/test_helpers.py
+++ b/decred/tests/unit/util/test_helpers.py
@@ -171,7 +171,7 @@ def test_appDataDir(monkeypatch):
     def testexpanduser(s):
         return ""
 
-    def testgetenv(s):
+    def testgetenv(s, d=""):
         return ""
 
     opSys = "Linux"

--- a/tinywallet/poetry.lock
+++ b/tinywallet/poetry.lock
@@ -7,7 +7,7 @@ python-versions = "*"
 version = "1.4.3"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Atomic file writes."
 marker = "sys_platform == \"win32\""
 name = "atomicwrites"
@@ -16,7 +16,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.3.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
@@ -85,7 +85,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "7.1.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Cross-platform colored terminal text."
 marker = "sys_platform == \"win32\""
 name = "colorama"
@@ -114,6 +114,15 @@ version = "0.29.16"
 
 [[package]]
 category = "main"
+description = "A backport of the dataclasses module for Python 3.6"
+marker = "python_version < \"3.7\""
+name = "dataclasses"
+optional = false
+python-versions = "*"
+version = "0.6"
+
+[[package]]
+category = "main"
 description = ""
 develop = true
 name = "decred"
@@ -126,6 +135,7 @@ appdirs = "^1.4.3"
 base58 = "^2.0.0"
 blake256 = "^0.1.1"
 pynacl = "^1.3.0"
+pytest-monkeytype = "^1.0.5"
 websocket_client = "^0.57.0"
 
 [package.source]
@@ -156,7 +166,7 @@ pycodestyle = ">=2.5.0,<2.6.0"
 pyflakes = ">=2.1.0,<2.2.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Read metadata from Python packages"
 marker = "python_version < \"3.8\""
 name = "importlib-metadata"
@@ -186,6 +196,26 @@ requirements = ["pipreqs", "pip-api"]
 xdg_home = ["appdirs (>=1.4.0)"]
 
 [[package]]
+category = "main"
+description = "A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7 and 3.8 programs."
+name = "libcst"
+optional = false
+python-versions = ">=3.6"
+version = "0.3.4"
+
+[package.dependencies]
+pyyaml = ">=5.2"
+typing-extensions = ">=3.7.2"
+typing-inspect = ">=0.4.0"
+
+[package.dependencies.dataclasses]
+python = "<3.7"
+version = "*"
+
+[package.extras]
+dev = ["black", "codecov", "coverage", "hypothesis (>=4.36.0)", "hypothesmith (>=0.0.4)", "isort", "flake8", "jupyter", "nbsphinx", "pyre-check", "sphinx", "sphinx-rtd-theme"]
+
+[[package]]
 category = "dev"
 description = "McCabe checker, plugin for flake8"
 name = "mccabe"
@@ -194,7 +224,19 @@ python-versions = "*"
 version = "0.6.1"
 
 [[package]]
-category = "dev"
+category = "main"
+description = "Generating type annotations from sampled production types"
+name = "monkeytype"
+optional = false
+python-versions = ">=3.6"
+version = "20.4.2"
+
+[package.dependencies]
+libcst = ">=0.3.4"
+mypy-extensions = "*"
+
+[[package]]
+category = "main"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
@@ -202,7 +244,15 @@ python-versions = ">=3.5"
 version = "8.2.0"
 
 [[package]]
-category = "dev"
+category = "main"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+name = "mypy-extensions"
+optional = false
+python-versions = "*"
+version = "0.4.3"
+
+[[package]]
+category = "main"
 description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
@@ -222,7 +272,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "0.8.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
 optional = false
@@ -238,7 +288,7 @@ version = ">=0.12"
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
 optional = false
@@ -286,7 +336,7 @@ docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
 tests = ["pytest (>=3.2.1,<3.3.0 || >3.3.0)", "hypothesis (>=3.27.0)"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python parsing module"
 name = "pyparsing"
 optional = false
@@ -313,7 +363,7 @@ python-versions = ">=3.5"
 version = "12.7.2"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
@@ -354,6 +404,26 @@ pytest = ">=3.6"
 testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "virtualenv"]
 
 [[package]]
+category = "main"
+description = "pytest-monkeytype: Generate Monkeytype annotations from your pytest tests."
+name = "pytest-monkeytype"
+optional = false
+python-versions = ">=3.6"
+version = "1.0.5"
+
+[package.dependencies]
+MonkeyType = ">=18.2.0"
+pytest = ">=3.2.0"
+
+[[package]]
+category = "main"
+description = "YAML parser and emitter for Python"
+name = "pyyaml"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "5.3.1"
+
+[[package]]
 category = "dev"
 description = "Alternative regular expression module, to replace re."
 name = "regex"
@@ -386,7 +456,27 @@ python-versions = "*"
 version = "1.4.1"
 
 [[package]]
-category = "dev"
+category = "main"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+name = "typing-extensions"
+optional = false
+python-versions = "*"
+version = "3.7.4.2"
+
+[[package]]
+category = "main"
+description = "Runtime inspection utilities for typing module."
+name = "typing-inspect"
+optional = false
+python-versions = "*"
+version = "0.5.0"
+
+[package.dependencies]
+mypy-extensions = ">=0.3.0"
+typing-extensions = ">=3.7.4"
+
+[[package]]
+category = "main"
 description = "Measures number of Terminal column cells of wide-character codes"
 name = "wcwidth"
 optional = false
@@ -405,7 +495,7 @@ version = "0.57.0"
 six = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
 name = "zipp"
@@ -550,6 +640,10 @@ cython = [
     {file = "Cython-0.29.16-py2.py3-none-any.whl", hash = "sha256:772c13250aea33ac17eb042544b310f0dc3862bbde49b334f5c12f7d1b627476"},
     {file = "Cython-0.29.16.tar.gz", hash = "sha256:232755284f942cbb3b43a06cd85974ef3c970a021aef19b5243c03ee2b08fa05"},
 ]
+dataclasses = [
+    {file = "dataclasses-0.6-py3-none-any.whl", hash = "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f"},
+    {file = "dataclasses-0.6.tar.gz", hash = "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"},
+]
 decred = []
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
@@ -567,13 +661,25 @@ isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
     {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
 ]
+libcst = [
+    {file = "libcst-0.3.4-py3-none-any.whl", hash = "sha256:625feffa383da08c148539ddb879fadb4090a775d9b97463209a0864a59d4828"},
+    {file = "libcst-0.3.4.tar.gz", hash = "sha256:449bf67813e4ced937edb9811355e2734ac709b4f36416889c6e169a03b96362"},
+]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
+monkeytype = [
+    {file = "MonkeyType-20.4.2-py3-none-any.whl", hash = "sha256:66b23ac7c6050cb5f7ca839a22c8a4881c0827d310d944e4c5f949a3f839e616"},
+    {file = "MonkeyType-20.4.2.tar.gz", hash = "sha256:ff04b25f2b0c8003ef000490edba97c79cc2fdb4f51cfabf3053bf8f03f2cf0a"},
+]
 more-itertools = [
     {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},
     {file = "more_itertools-8.2.0-py3-none-any.whl", hash = "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
     {file = "packaging-20.3-py2.py3-none-any.whl", hash = "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"},
@@ -663,6 +769,22 @@ pytest-cov = [
     {file = "pytest-cov-2.8.1.tar.gz", hash = "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b"},
     {file = "pytest_cov-2.8.1-py2.py3-none-any.whl", hash = "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"},
 ]
+pytest-monkeytype = [
+    {file = "pytest-monkeytype-1.0.5.tar.gz", hash = "sha256:1bb318d1eccf0f4642a05320dd215b30ec9663c7c831549fdbcb99cb0c54f01f"},
+]
+pyyaml = [
+    {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
+    {file = "PyYAML-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
+]
 regex = [
     {file = "regex-2020.4.4-cp27-cp27m-win32.whl", hash = "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f"},
     {file = "regex-2020.4.4-cp27-cp27m-win_amd64.whl", hash = "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1"},
@@ -717,6 +839,16 @@ typed-ast = [
     {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
     {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.2-py2-none-any.whl", hash = "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"},
+    {file = "typing_extensions-3.7.4.2-py3-none-any.whl", hash = "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5"},
+    {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
+]
+typing-inspect = [
+    {file = "typing_inspect-0.5.0-py2-none-any.whl", hash = "sha256:75c97b7854426a129f3184c68588db29091ff58e6908ed520add1d52fc44df6e"},
+    {file = "typing_inspect-0.5.0-py3-none-any.whl", hash = "sha256:c6ed1cd34860857c53c146a6704a96da12e1661087828ce350f34addc6e5eee3"},
+    {file = "typing_inspect-0.5.0.tar.gz", hash = "sha256:811b44f92e780b90cfe7bac94249a4fae87cfaa9b40312765489255045231d9c"},
 ]
 wcwidth = [
     {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},


### PR DESCRIPTION
This adds type hints to `dcr/util/helpers.py` and `dcr/util/tinyhttp.py`.

It also adds the [mypy](https://mypy.readthedocs.io/) static type checker and the `pytest-monkeytype` pytest plugin to the `decred` dev. dependencies.

Part of #178.