### PR TITLE
screens: Continue on open file cancel.

### DIFF
--- a/decred/decred/util/database.py
+++ b/decred/decred/util/database.py
@@ -60,6 +60,25 @@ KVLast = "SELECT k, v FROM {tablename} ORDER BY k DESC LIMIT 1;"
 KVFirst = "SELECT k, v FROM {tablename} ORDER BY k LIMIT 1;"
 
 
+def isSqlite3DB(filepath):
+    """
+    Returns whether file at filepath is a sqlite3 database.
+
+    Args:
+        filepath (str): The file to check.
+
+    Returns:
+        bool: Whether the database could be opened and queried.
+    """
+    try:
+        conn = sqlite3.connect(filepath)
+        conn.execute("pragma schema_version;")
+    except Exception:
+        return False
+    conn.close()
+    return True
+
+
 class KeyValueDatabase:
     """
     A KeyValueDatabase is a sqlite3 database specialized for two-column tables


### PR DESCRIPTION
closes #172 

Rather than throwing an exception when restoring a wallet from file,
just return, allowing the user to do something else.

Create a logging helper for errors that logs to stdErr and the main ui
window.

Do not move a user's wallet file without warning. Copy it instead.

Check that the file is a sqlite database, otherwise you get stuck in a
loop until you delete or move the file manually.

The method for checking whether the database is valid comes from here: https://stackoverflow.com/questions/3888529/how-to-tell-if-sqlite-database-file-is-valid-or-not