### PR TITLE
multi: Fix rpclisten config parsing

### DIFF
--- a/decred/decred/util/helpers.py
+++ b/decred/decred/util/helpers.py
@@ -156,7 +156,7 @@ def readINI(path, keys):
     Returns:
         dict: Discovered keys and values.
     """
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(strict=False)
     # Need to add a section header since configparser doesn't handle sectionless
     # INI format.
     with open(path) as f:
@@ -214,12 +214,13 @@ def makeWebsocketURL(baseURL, path):
     Turn the HTTP/HTTPS URL into a WS/WSS one.
 
     Args:
-        url (str): The base URL.
+        baseURL (str): The base URL.
         path (str): The websocket endpoint path. e.g. path of "ws" will yield
             URL wss://yourhost.com/ws.
     Returns:
         string: the WebSocket URL.
     """
+    baseURL = f"wss://{baseURL}" if "//" not in baseURL else baseURL
     url = urlsplit(baseURL)
     scheme = "wss" if url.scheme in ("https", "wss") else "ws"
     return urlunsplit((scheme, url.netloc, f"/{path}", "", ""))

--- a/decred/tests/unit/util/test_helpers.py
+++ b/decred/tests/unit/util/test_helpers.py
@@ -178,3 +178,22 @@ def test_appDataDir(monkeypatch):
     monkeypatch.setattr(os.path, "expanduser", testexpanduser)
     monkeypatch.setattr(os, "getenv", testgetenv)
     assert helpers.appDataDir(appName) == "."
+
+
+def test_makeWebsocketURL():
+    """
+    Tests are 3-tuples:
+
+    baseURL (str): The base URL.
+    path (str): The websocket endpoint path.
+    want (str): The expected result.
+    """
+    tests = [
+        ("https://localhost:19556", "ws", "wss://localhost:19556/ws"),
+        ("http://localhost:8337", "ws1", "ws://localhost:8337/ws1"),
+        ("ws://localhost:9999", "ws2", "ws://localhost:9999/ws2"),
+        ("wss://localhost", "ws3", "wss://localhost/ws3"),
+        ("localhost:1234", "ws4", "wss://localhost:1234/ws4"),
+    ]
+    for baseURL, path, want in tests:
+        assert helpers.makeWebsocketURL(baseURL, path) == want

--- a/tinywallet/tinywallet/screens.py
+++ b/tinywallet/tinywallet/screens.py
@@ -1445,10 +1445,11 @@ class DCRDConfigScreen(Screen):
         grid.addWidget(Q.makeLabel("dcrd URL", 14, Q.ALIGN_LEFT), row, 0, 1, 3)
         grid.addWidget(Q.makeLabel("RPC username", 14, Q.ALIGN_LEFT), row, 3)
         row += 1
-        defaultRpclisten = f"127.0.0.1:{nets.DcrdPorts[cfg.netParams.Name]}"
-        host = nodeConfig.get("rpclisten", defaultRpclisten)
+        dcrdCfg = config.dcrd(cfg.netParams)
+        host = nodeConfig.get("rpclisten", dcrdCfg["rpclisten"])
+        scheme = "https" if not dcrdCfg["notls"] else "http"
 
-        self.rpcListen = QtWidgets.QLineEdit(f"https://{host}/")
+        self.rpcListen = QtWidgets.QLineEdit(f"{scheme}://{host}/")
         grid.addWidget(self.rpcListen, row, 0, 1, 3)
         self.rpcUser = QtWidgets.QLineEdit(nodeConfig.get("rpcuser", ""))
         grid.addWidget(self.rpcUser, row, 3)


### PR DESCRIPTION
This updates tinywallet.config to correctly parse rpclisten from the
dcrd config file, to be used as the default URL when configuring the
dcrd connection in tinywallet.

Fixes https://github.com/decred/tinydecred/issues/190