### PR TITLE
tinywallet: installation and high dpi fixes

### DIFF
--- a/decred/pyproject.toml
+++ b/decred/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "decred"
-version = "0.0.1"
+version = "0.1.2-dev"
 description = "A Python 3 Decred toolkit."
 license = "ISC"
 homepage = "https://decred.org/"
@@ -61,5 +61,5 @@ skip = [
 ]
 
 [build-system]
-requires = ["poetry>=1.0.3"]
+requires = ["setuptools", "poetry>=1.0.3"]
 build-backend = "poetry.masonry.api"

--- a/tinywallet/poetry.lock
+++ b/tinywallet/poetry.lock
@@ -119,7 +119,7 @@ develop = true
 name = "decred"
 optional = false
 python-versions = "^3.6"
-version = "0.0.1"
+version = "0.1.2-dev"
 
 [package.dependencies]
 appdirs = "^1.4.3"

--- a/tinywallet/tinywallet/app.py
+++ b/tinywallet/tinywallet/app.py
@@ -516,11 +516,13 @@ def main():
     """
     Start the TinyWallet application.
     """
+    os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
     sys.excepthook = exception_hook
     QtWidgets.QApplication.setDesktopSettingsAware(False)
     roboFont = QtGui.QFont("Roboto")
     roboFont.setPixelSize(16)
     QtWidgets.QApplication.setFont(roboFont)
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
     qApp = QtWidgets.QApplication(sys.argv)
     qApp.setStyleSheet(Q.QUTILITY_STYLE)
     qApp.setPalette(Q.lightThemePalette)


### PR DESCRIPTION
Applies a fix roughly equivalent to #195 to master. The solution from #195 is apparently suitable for installing **decred**, but not for installing **tinywallet** with the local **decred** dependency, for some reason. 

Also fixes PyQt rendering for high-dpi screens.